### PR TITLE
feat:상품 관리 화면 아이템 토글 버튼 수정

### DIFF
--- a/project/client/src/Components/AdminComponents/AdminManageProductItemList.tsx
+++ b/project/client/src/Components/AdminComponents/AdminManageProductItemList.tsx
@@ -4,7 +4,10 @@ import ProductItem from "./ProductItem";
 import { ProductListValues } from "../../mockup/productList";
 import StateMenuBar from "./StateMenuBar";
 import { useRecoilState } from "recoil";
-import { productListState } from "../../productItemState";
+import {
+  productListState,
+  selectProductListState,
+} from "../../state/productItemState";
 
 const Container = styled.div`
   h1 {
@@ -23,7 +26,9 @@ const Container = styled.div`
 
 const AdminManageProductItemList = () => {
   const [productList, setProductList] = useRecoilState(productListState);
-  const [selectList, setSelectList] = useState<ProductListValues[]>([]);
+  const [selectList, setSelectList] = useRecoilState<ProductListValues[]>(
+    selectProductListState,
+  );
 
   const selectHandler = (event: React.MouseEvent<HTMLLIElement>) => {
     const id = event.currentTarget.dataset.id;
@@ -31,7 +36,7 @@ const AdminManageProductItemList = () => {
     const selectProduct = productList.filter((item) => item.id === Number(id));
 
     id &&
-      setSelectList((prevState: ProductListValues[]) => {
+      setSelectList((prevState) => {
         const itemIndex = prevState.findIndex(
           (value) => value.id === Number(id),
         );
@@ -54,6 +59,7 @@ const AdminManageProductItemList = () => {
                 id={item.id}
                 name={item.name}
                 price={item.price}
+                select={item.select}
                 handler={selectHandler}
               />
             ))}

--- a/project/client/src/Components/AdminComponents/AdminMenu.tsx
+++ b/project/client/src/Components/AdminComponents/AdminMenu.tsx
@@ -15,7 +15,7 @@ const AdminMenu = () => {
           <Link to="#">스탭 주문 화면</Link>
         </li>
         <li>
-          <Link to="#">메뉴 관리하기</Link>
+          <Link to="/admin/1/manage-product">메뉴 관리하기</Link>
         </li>
       </ul>
     </Wrapper>

--- a/project/client/src/Components/AdminComponents/ProductItem.tsx
+++ b/project/client/src/Components/AdminComponents/ProductItem.tsx
@@ -1,5 +1,11 @@
 import React, { useState } from "react";
+import { useRecoilState } from "recoil";
 import styled, { StyledComponent } from "styled-components";
+import { ProductListValues } from "../../mockup/productList";
+import {
+  productListState,
+  selectProductListState,
+} from "../../state/productItemState";
 
 const Item: React.FC<
   | IProductItemProps
@@ -45,15 +51,23 @@ const ProductItem: React.FC<IProductItemProps> = ({
   price,
   imageUrl,
   handler,
+  select,
 }) => {
-  const [select, setSelect] = useState(false);
+  const [productList, setProductList] = useRecoilState(productListState);
   return (
     <Item
       data-id={id}
       select={select}
       onClick={(e) => {
         handler && handler(e);
-        setSelect(!select);
+        setProductList((item) =>
+          [
+            ...item.filter((value) => value.id !== id),
+            ...item
+              .filter((value) => value.id === id)
+              .map((item) => ({ ...item, select: !item.select })),
+          ].sort((a, b) => (a.id > b.id ? 1 : -1)),
+        );
       }}
     >
       <div>

--- a/project/client/src/productItemState.ts
+++ b/project/client/src/productItemState.ts
@@ -1,7 +1,0 @@
-import { atom } from "recoil";
-import { productList } from "./mockup/productList";
-
-export const productListState = atom({
-  key: "productList",
-  default: productList,
-});

--- a/project/client/src/state/productItemState.ts
+++ b/project/client/src/state/productItemState.ts
@@ -1,0 +1,12 @@
+import { atom } from "recoil";
+import { productList, ProductListValues } from "../mockup/productList";
+
+export const productListState = atom({
+  key: "productList",
+  default: productList,
+});
+
+export const selectProductListState = atom({
+  key: "selectProductList",
+  default: <ProductListValues[]>[],
+});


### PR DESCRIPTION
추가 : selectProductListState
  - key: "selectProductList",
  - default: <ProductListValues[]>[]
  - desc : 삭제하기 위해 선택한 상품을 임시로 저장하는 Recoil atom

수정
AdminManageProductItemList
    - selectList를 useState에서 useRecoilState로 변경
AdminMenu
    - 메뉴 관리하기에 link path 추가 : /admin/1/manage-product
Modal
    - selectList를 useState에서 useRecoilState로 변경
    - 상품 삭제 취소, 삭제시 전역 상태에서 상태값 변경
ProductItem
    - select는 전역 상태에서 부모로부터 값을 받도록 수정
    - onClick 이벤트 클릭시 변경된 select 값을 전역 상태에 반영하도록 수정

# 개요
자신이 작업한 내용의 개요를 적어주세요.


# 작업 내용
어느 부분이 변경되었는지 혹은 어떤 기능을 추가하였는지 등을 적어주세요. 

# 스크린샷 
필요하다면 첨부해주세요.

pull requests 내용을 작성하실때 'resolve: #[이슈넘버]'를 넣어주시면 merge될 때, 깃허브에서 자동으로 이슈를 close해줍니다.
