### PR TITLE
주문 목록 화면에서 수량 변경, 삭제, 하단 상태 바에 업데이트 완료

### DIFF
--- a/src/Page/Client/ClientMenu.tsx
+++ b/src/Page/Client/ClientMenu.tsx
@@ -77,9 +77,10 @@ const Item = styled.button`
 `;
 
 export interface IOrderSelectedItem {
-  id: number;
+  productId: number;
   name: string;
   option?: string;
+  price: number;
   totalCount: number;
   totalPrice: number;
 }

--- a/src/Page/Client/ClientSelectList.tsx
+++ b/src/Page/Client/ClientSelectList.tsx
@@ -8,6 +8,7 @@ import { Headline1 } from "../../mixin";
 import OrderStateBar from "./OrderStateBar";
 import PaymentModalChildren from "./Modal/PaymentModalChildren";
 import { useNavigate } from "react-router-dom";
+import ButtonDefaultStyle from "../../Components/Buttons/ButtonDefault";
 
 const Header = styled.div`
   display: flex;
@@ -30,9 +31,18 @@ const Header = styled.div`
 `;
 
 const MenuListItem = styled.div`
+  display: grid;
+  grid-template-columns: 20% 50% 30%;
+  padding: 0.5rem 0;
   border-bottom: 1px solid black;
-  width: 100%;
-  padding-bottom: 1rem;
+  img {
+    border: 1px solid;
+    border-color: ${(props) => props.theme.color.gray300};
+  }
+  div {
+    /* display: grid; */
+    padding: 0 0.5rem;
+  }
   h2 {
     font-size: 2rem;
     font-weight: bold;
@@ -42,6 +52,9 @@ const MenuListItem = styled.div`
     font-size: 1.5rem;
     padding: 0.3rem 0;
   }
+`;
+const DeleteButton = styled(ButtonDefaultStyle)`
+  background-color: ${(props) => props.theme.color.gray300};
 `;
 
 const ClientSelectList = () => {
@@ -71,20 +84,19 @@ const ClientSelectList = () => {
           totalCount: newCount,
           totalPrice: selected.price * newCount,
         },
-      ].sort(function (a, b) {
+      ].sort((a: any, b: any) => {
         if (a.productId === b.productId) {
-          return a.option && b.option && a.option > b.option ? 1 : -1;
-        } else {
-          return a.productId - b.productId;
+          return a?.option > b?.option ? 1 : -1;
         }
+        return a.productId - b.productId;
       })
     );
   };
 
   const handleMinusCount = (current: IOrderSelectedItem) => {
-    let [selected] = totalSelectMenu.filter(
-      (menu) => menu.productId === current.productId
-    );
+    let [selected] = totalSelectMenu
+      .filter((menu) => menu.productId === current.productId)
+      .filter((menu) => menu.option === current.option);
     let newCount = selected.totalCount - 1;
     if (newCount < 1) {
       return;
@@ -97,7 +109,12 @@ const ClientSelectList = () => {
           totalCount: newCount,
           totalPrice: selected.price * newCount,
         },
-      ].sort((a, b) => (a.productId > b.productId ? 1 : -1))
+      ].sort((a: any, b: any) => {
+        if (a.productId === b.productId) {
+          return a?.option > b?.option ? 1 : -1;
+        }
+        return a.productId - b.productId;
+      })
     );
   };
 
@@ -124,16 +141,23 @@ const ClientSelectList = () => {
 
       {totalSelectMenu.map((item, i) => (
         <MenuListItem key={`${item.productId}_${i}`}>
-          <h2>{item.name}</h2>
-          <button onClick={() => handleDelete(item)}>삭제하기</button>
-          {item.option && <p>{item.option}</p>}
-          <p>총 가격: {item.totalPrice}</p>
-          <p>
-            주문수량:
-            <button onClick={() => handleMinusCount(item)}>-</button>
-            {item.totalCount}
-            <button onClick={() => handleAddCount(item)}>+</button>
-          </p>
+          <img src="" />
+          <div>
+            <h2>{item.name}</h2>
+            {item.option && <p>선택옵션: {item.option}</p>}
+            <p>
+              주문수량:
+              <button onClick={() => handleMinusCount(item)}>-</button>
+              {item.totalCount}
+              <button onClick={() => handleAddCount(item)}>+</button>
+            </p>
+          </div>
+          <div>
+            <p>총 가격: {item.totalPrice}</p>
+            <DeleteButton onClick={() => handleDelete(item)}>
+              삭제하기
+            </DeleteButton>
+          </div>
         </MenuListItem>
       ))}
 

--- a/src/Page/Client/Modal/MenuItemModalChildren.tsx
+++ b/src/Page/Client/Modal/MenuItemModalChildren.tsx
@@ -28,56 +28,63 @@ const MenuItemModalChildren: React.FC<IMenuItemModalChildrenProps> = ({
 }) => {
   const orderSelectedItem = () => {
     const [sameMenu] = orderItem.filter(
-      (ordered) => ordered.productId === selectedItem[0].id
+      (ordered) =>
+        ordered.productId === selectedItem[0].id &&
+        ordered.option === selectedOption
     );
+    const { option: hasOption }: any = selectedItem[0];
 
-    if (
-      count === 0 ||
-      (selectedItem[0].option?.length !== 0 && selectedOption === "")
-    ) {
-      alert("수량과 옵션을 선택해주세요");
-    } else {
-      if (sameMenu && sameMenu.option === selectedOption) {
-        setOrderItem((orderItem) =>
-          [
-            ...orderItem.filter((el) => el !== sameMenu),
-            {
-              ...sameMenu,
-              totalCount: sameMenu.totalCount + count,
-              totalPrice: sameMenu.totalPrice + sameMenu.price + count,
-            },
-          ].sort(function (a, b) {
-            if (a.productId === b.productId) {
-              return a.option && b.option && a.option > b.option ? 1 : -1;
-            } else {
-              return a.productId - b.productId;
-            }
-          })
-        );
-      } else {
-        setOrderItem((orderItem) =>
-          [
-            ...orderItem,
-            {
-              productId: selectedItem[0].id,
-              name: selectedItem[0].name,
-              option: selectedOption,
-              price: selectedItem[0].price,
-              totalCount: count,
-              totalPrice: selectedItem[0].price * count,
-            },
-          ].sort(function (a, b) {
-            if (a.productId === b.productId) {
-              return a.option && b.option && a.option > b.option ? 1 : -1;
-            } else {
-              return a.productId - b.productId;
-            }
-          })
-        );
-      }
-      setCount(0);
-      setIsModal(false);
+    if (count === 0) {
+      alert("수량을 선택해주세요");
+      return;
     }
+
+    if (hasOption?.length > 0 && !selectedOption) {
+      alert("옵션을 선택하세요");
+      return;
+    }
+
+    if (!sameMenu || sameMenu.option !== selectedOption) {
+      setOrderItem((orderItem) =>
+        [
+          ...orderItem,
+          {
+            productId: selectedItem[0].id,
+            name: selectedItem[0].name,
+            option: selectedOption,
+            price: selectedItem[0].price,
+            totalCount: count,
+            totalPrice: selectedItem[0].price * count,
+          },
+        ].sort((a: any, b: any) => {
+          if (a.productId === b.productId) {
+            return a?.option > b?.option ? 1 : -1;
+          }
+          return a.productId - b.productId;
+        })
+      );
+    }
+
+    if (sameMenu?.option === selectedOption) {
+      setOrderItem((orderItem) =>
+        [
+          ...orderItem.filter((el) => el !== sameMenu),
+          {
+            ...sameMenu,
+            totalCount: sameMenu.totalCount + count,
+            totalPrice: sameMenu.totalPrice + sameMenu.price + count,
+          },
+        ].sort((a: any, b: any) => {
+          if (a.productId === b.productId) {
+            return a?.option > b?.option ? 1 : -1;
+          }
+          return a.productId - b.productId;
+        })
+      );
+    }
+
+    setCount(0);
+    setIsModal(false);
   };
 
   const cancelItem = () => {

--- a/src/Page/Client/Modal/MenuItemModalChildren.tsx
+++ b/src/Page/Client/Modal/MenuItemModalChildren.tsx
@@ -27,18 +27,57 @@ const MenuItemModalChildren: React.FC<IMenuItemModalChildrenProps> = ({
   setOrderItem,
 }) => {
   const orderSelectedItem = () => {
-    setOrderItem([
-      ...orderItem,
-      {
-        id: selectedItem[0].id,
-        name: selectedItem[0].name,
-        option: selectedOption,
-        totalCount: count,
-        totalPrice: selectedItem[0].price * count,
-      },
-    ]);
-    setCount(0);
-    setIsModal(false);
+    const [sameMenu] = orderItem.filter(
+      (ordered) => ordered.productId === selectedItem[0].id
+    );
+
+    if (
+      count === 0 ||
+      (selectedItem[0].option?.length !== 0 && selectedOption === "")
+    ) {
+      alert("수량과 옵션을 선택해주세요");
+    } else {
+      if (sameMenu && sameMenu.option === selectedOption) {
+        setOrderItem((orderItem) =>
+          [
+            ...orderItem.filter((el) => el !== sameMenu),
+            {
+              ...sameMenu,
+              totalCount: sameMenu.totalCount + count,
+              totalPrice: sameMenu.totalPrice + sameMenu.price + count,
+            },
+          ].sort(function (a, b) {
+            if (a.productId === b.productId) {
+              return a.option && b.option && a.option > b.option ? 1 : -1;
+            } else {
+              return a.productId - b.productId;
+            }
+          })
+        );
+      } else {
+        setOrderItem((orderItem) =>
+          [
+            ...orderItem,
+            {
+              productId: selectedItem[0].id,
+              name: selectedItem[0].name,
+              option: selectedOption,
+              price: selectedItem[0].price,
+              totalCount: count,
+              totalPrice: selectedItem[0].price * count,
+            },
+          ].sort(function (a, b) {
+            if (a.productId === b.productId) {
+              return a.option && b.option && a.option > b.option ? 1 : -1;
+            } else {
+              return a.productId - b.productId;
+            }
+          })
+        );
+      }
+      setCount(0);
+      setIsModal(false);
+    }
   };
 
   const cancelItem = () => {
@@ -50,7 +89,6 @@ const MenuItemModalChildren: React.FC<IMenuItemModalChildrenProps> = ({
 
   return (
     <>
-      <h2> 선택하신 메뉴요</h2>
       <h2>{selectedItem[0].name}</h2>
       <p>주문 수: {count}</p>
       <p>주문 가격: {count * Number(selectedItem[0].price)}</p>
@@ -64,8 +102,22 @@ const MenuItemModalChildren: React.FC<IMenuItemModalChildrenProps> = ({
         </OptionButton>
       ))}
 
-      <button onClick={() => setCount(count - 1)}>-</button>
-      <button onClick={() => setCount(count + 1)}>+</button>
+      <button
+        onClick={() => {
+          if (count < 1) return;
+          setCount(count - 1);
+        }}
+      >
+        -
+      </button>
+      <button
+        onClick={() => {
+          if (count < 0) return;
+          setCount(count + 1);
+        }}
+      >
+        +
+      </button>
       <button onClick={cancelItem}>취소하기</button>
       <button onClick={orderSelectedItem}>주문하기</button>
     </>

--- a/src/Page/Client/Modal/PaymentModalChildren.tsx
+++ b/src/Page/Client/Modal/PaymentModalChildren.tsx
@@ -40,14 +40,15 @@ const PaymentModalChildren: React.FC<IPaymentModalChildrenProps> = ({
   };
   return (
     <PaymentBox>
-      {!isPaid ? (
+      {!isPaid && (
         <>
           <h2>결제중입니다</h2>
           <p>카드를 삽입해주세요</p>
           <button onClick={() => setIsPaid(true)}>결제완료</button>
           <button onClick={() => setIsModal(false)}>취소하기</button>
         </>
-      ) : !isPrint ? (
+      )}
+      {!isPaid && !isPrint ? (
         <>
           <h2>결제가 완료되었습니다</h2>
           <p>영수증을 출력하시겠습니까?</p>

--- a/src/Page/Client/Modal/PaymentModalChildren.tsx
+++ b/src/Page/Client/Modal/PaymentModalChildren.tsx
@@ -1,7 +1,68 @@
-import React from "react";
+import React, { useState } from "react";
+import { useNavigate } from "react-router-dom";
+import styled from "styled-components";
+import { useRecoilState } from "recoil";
+import { selectMenuListState } from "../../../state/productItemState";
 
-const PaymentModalChildren = () => {
-  return <div>결제창</div>;
+interface IPaymentModalChildrenProps {
+  setIsModal: React.Dispatch<React.SetStateAction<boolean>>;
+}
+
+const PaymentBox = styled.div`
+  p {
+    font-size: 1.5rem;
+    padding: 0.3rem 0;
+  }
+`;
+
+const PaymentModalChildren: React.FC<IPaymentModalChildrenProps> = ({
+  setIsModal,
+}) => {
+  const navigate = useNavigate();
+
+  // paid done
+  const [isPaid, setIsPaid] = useState(false);
+  // print done
+  const [isPrint, setIsPrint] = useState(false);
+
+  // handle print receipt
+  const [printReceipt, setPrintReceipt] = useState<Boolean>(false);
+  const handleReceipt = (receipt: Boolean) => {
+    setPrintReceipt(receipt);
+    setIsPrint(true);
+  };
+
+  // reset all menu list and go back to Main
+  const [orderList, setOrderList] = useRecoilState(selectMenuListState);
+  const confirmOrder = () => {
+    setOrderList([]);
+    navigate("/client/main");
+  };
+  return (
+    <PaymentBox>
+      {!isPaid ? (
+        <>
+          <h2>결제중입니다</h2>
+          <p>카드를 삽입해주세요</p>
+          <button onClick={() => setIsPaid(true)}>결제완료</button>
+          <button onClick={() => setIsModal(false)}>취소하기</button>
+        </>
+      ) : !isPrint ? (
+        <>
+          <h2>결제가 완료되었습니다</h2>
+          <p>영수증을 출력하시겠습니까?</p>
+          <button onClick={() => handleReceipt(true)}>예</button>
+          <button onClick={() => handleReceipt(false)}>아니요</button>
+        </>
+      ) : (
+        <>
+          <h2>주문이 완료되었습니다</h2>
+          <p>주문 번호를 확인해주세요</p>
+          <button onClick={confirmOrder}>확인</button>
+        </>
+      )}
+    </PaymentBox>
+  );
 };
 
 export default PaymentModalChildren;

--- a/src/Page/Client/OrderStateBar.tsx
+++ b/src/Page/Client/OrderStateBar.tsx
@@ -1,5 +1,4 @@
 import React from "react";
-import { useNavigate } from "react-router-dom";
 import styled from "styled-components";
 
 const MenuBarContainer = styled.div`
@@ -36,6 +35,7 @@ interface ITotalOrderMenu {
   totalCount: number;
   totalPrice: number;
   label: string;
+  goBack?: (value: any) => void;
   handler?: (value: any) => void;
 }
 
@@ -43,6 +43,7 @@ const OrderStateBar: React.FC<ITotalOrderMenu> = ({
   totalCount = 0,
   totalPrice = 0,
   label,
+  goBack,
   handler,
 }) => {
   return (
@@ -52,6 +53,7 @@ const OrderStateBar: React.FC<ITotalOrderMenu> = ({
           총 상품 수: {totalCount} 개 &nbsp;&nbsp;&nbsp; 주문 가격:
           {totalPrice} 원
         </h2>
+        {goBack && <button onClick={goBack}>돌아가기</button>}
         <button onClick={handler}>{label}</button>
       </MenuBarContainer>
     </div>


### PR DESCRIPTION
# 개요
고객 주문 목록 화면에서 수량 변경 및 삭제, 하단 상태 바에 총 수량 및 가격 반영

# 작업 내용
고객 주문 목록 화면에서 수량 변경 및 삭제, 하단 상태 바에 총 수량 및 가격 반영되도록 업데이트 했습니다. 
옵션 포함한 주문 목록 생성, 주문 목록에서 옵션 값이 다를 경우 분리해서 보여줍니다.
결제 이후 메인으로 돌아가는 기능 구현은 아웃라인만 완료했고 화면 구현 및 세부적인 내용 업데이트 필요합니다. 
(추가로 결제진행 모달 창에서 전체 주문 메뉴 불러오는 기능 필요합니다)

# 스크린샷 
필요하다면 첨부해주세요.

