### PR TITLE
feat:로그인 mutation, me query, 상태 유지 로직 추가

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,8 +1,26 @@
-import React from "react";
+import React, { useEffect, useMemo } from "react";
 import { BrowserRouter } from "react-router-dom";
+import { useRecoilState, useSetRecoilState } from "recoil";
 import Router from "./Routers/Routers";
+import { userState } from "./state/userState";
+import useGetUserInfoFromLocalStorage from "./utils/customHooks/useGetUserStateFromLocalStorage";
 
 function App() {
+  const [user, setUser] = useRecoilState(userState);
+  const { getUser } = useGetUserInfoFromLocalStorage();
+
+  useMemo(() => {
+    const storageUser = getUser();
+
+    if (!storageUser) {
+      return;
+    }
+
+    if (!user.isLogin) {
+      setUser(storageUser);
+    }
+  }, [user]);
+
   return (
     <BrowserRouter>
       <Router />

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo } from "react";
+import React, { useEffect } from "react";
 import { BrowserRouter } from "react-router-dom";
 import { useRecoilState, useSetRecoilState } from "recoil";
 import Router from "./Routers/Routers";
@@ -9,17 +9,13 @@ function App() {
   const [user, setUser] = useRecoilState(userState);
   const { getUser } = useGetUserInfoFromLocalStorage();
 
-  useMemo(() => {
+  useEffect(() => {
     const storageUser = getUser();
-
     if (!storageUser) {
       return;
     }
-
-    if (!user.isLogin) {
-      setUser(storageUser);
-    }
-  }, [user]);
+    setUser(storageUser);
+  }, [setUser]);
 
   return (
     <BrowserRouter>

--- a/src/Components/Buttons/ButtonDefault.tsx
+++ b/src/Components/Buttons/ButtonDefault.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { ReactNode } from "react";
 import styled from "styled-components";
 
 const Button: React.FC<IButtonDefaultStyle> = styled.button<IButtonDefaultStyle>`
@@ -16,7 +16,7 @@ interface IButtonDefaultStyle
     React.ButtonHTMLAttributes<HTMLButtonElement>,
     HTMLButtonElement
   > {
-  children: JSX.Element | string;
+  children: ReactNode;
 }
 
 const ButtonDefaultStyle: React.FC<IButtonDefaultStyle> = ({

--- a/src/Components/Loading.tsx
+++ b/src/Components/Loading.tsx
@@ -1,0 +1,115 @@
+import React from "react";
+import styled from "styled-components";
+import { Headline1, SubTitle2 } from "../mixin";
+import { motion, Variants } from "framer-motion";
+
+const Wrapper = styled(motion.div)`
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+`;
+
+const TransparentBackground = styled(motion.div)`
+  position: absolute;
+  z-index: -1;
+  top: 0;
+  width: 100%;
+  height: 100%;
+  background-color: ${(props) => props.theme.color.backgroundBlack80};
+  overflow: hidden;
+`;
+
+const FontContainer = styled.div`
+  width: 100%;
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+`;
+
+const Title = styled(motion.h1)`
+  ${Headline1};
+  color: ${(props) => props.theme.color.fontColorWhite};
+`;
+
+const SubTitle = styled(motion.p)`
+  ${SubTitle2};
+  color: ${(props) => props.theme.color.fontColorWhite};
+`;
+
+const LoadingImageContainer = styled.div`
+  position: relative;
+`;
+
+const LoadingImage = styled(motion.div)`
+  position: absolute;
+  width: 0.5rem;
+  height: 0.5rem;
+  background-color: ${(props) => props.theme.color.background100};
+  border-radius: 0.5rem;
+`;
+
+const loadingBackgroundVariants: Variants = {
+  init: {
+    opacity: 0,
+  },
+  animate: {
+    opacity: 1,
+    transition: {
+      duration: 1,
+      delayChildren: 1,
+      staggerChildren: 0.5,
+    },
+  },
+  exit: {
+    opacity: 0,
+  },
+};
+
+const loadingImageVariants: Variants = {
+  init: {
+    opacity: 0,
+  },
+  animate: {
+    y: [0, -25],
+    opacity: 1,
+    transition: {
+      y: { yoyo: Infinity, duration: 1, ease: "easeInOut" },
+    },
+  },
+  exit: {
+    opacity: 0,
+  },
+};
+
+interface ILoadingProps {
+  title: string;
+  subTitle?: string;
+}
+
+const Loading = ({ title, subTitle }: ILoadingProps) => {
+  return (
+    <Wrapper
+      variants={loadingBackgroundVariants}
+      initial="init"
+      animate="animate"
+      exit="exit"
+    >
+      <FontContainer>
+        <LoadingImageContainer>
+          <LoadingImage variants={loadingImageVariants} />
+          <LoadingImage variants={loadingImageVariants} />
+          <LoadingImage variants={loadingImageVariants} />
+        </LoadingImageContainer>
+        <Title>{title}</Title>
+        {subTitle && <SubTitle>{subTitle}</SubTitle>}
+      </FontContainer>
+      <TransparentBackground />
+    </Wrapper>
+  );
+};
+
+export default Loading;

--- a/src/Components/PageHeader.tsx
+++ b/src/Components/PageHeader.tsx
@@ -1,0 +1,32 @@
+import React from "react";
+import styled from "styled-components";
+import { Headline2, SubTitle1 } from "../mixin";
+
+interface IPageMessageHeaderProps {
+  header: string;
+  message?: string;
+}
+
+const Wrapper = styled.div`
+  display: flex;
+  align-items: center;
+  h2 {
+    ${Headline2}
+  }
+  h3 {
+    ${SubTitle1}
+    font-weight:400;
+    margin-left: 2rem;
+  }
+`;
+
+const PageHeaderMessage = ({ header, message }: IPageMessageHeaderProps) => {
+  return (
+    <Wrapper>
+      <h2>{header}</h2>
+      <h3>{message}</h3>
+    </Wrapper>
+  );
+};
+
+export default PageHeaderMessage;

--- a/src/Layouts/AdminLayout.tsx
+++ b/src/Layouts/AdminLayout.tsx
@@ -4,6 +4,8 @@ import styled from "styled-components";
 import Nav from "../Components/Nav/Nav";
 import { Headline1 } from "../mixin";
 import { GiHamburgerMenu } from "react-icons/gi";
+import { useRecoilValue } from "recoil";
+import { userState } from "../state/userState";
 
 const Wrapper = styled.div`
   padding: 1rem 2rem;
@@ -31,7 +33,7 @@ const Link = styled(NavLink)``;
 const Main = styled.main``;
 
 const AdminLayout = () => {
-  const [isLogin, setIsLogin] = useState(false);
+  const user = useRecoilValue(userState);
   const [isMenu, setIsMenu] = useState(false);
 
   useEffect(() => {
@@ -48,10 +50,7 @@ const AdminLayout = () => {
         {isMenu && (
           <Nav setNavState={setIsMenu}>
             <>
-              <li>
-                <Link to="/admin/login">로그인</Link>
-              </li>
-              {isLogin && (
+              {user.isLogin && (
                 <>
                   <li>
                     <Link to=":id/store/list">가게목록</Link>

--- a/src/Page/Admin/Login/AdminLoadingAndGetUser.tsx
+++ b/src/Page/Admin/Login/AdminLoadingAndGetUser.tsx
@@ -1,15 +1,18 @@
 import React, { useEffect } from "react";
 import { useNavigate } from "react-router-dom";
 import { useRecoilState } from "recoil";
+import Loading from "../../../Components/Loading";
 import { MeQuery, useMeQuery } from "../../../generated/graphql";
 import graphqlReqeustClient from "../../../lib/graphqlRequestClient";
 import { userState } from "../../../state/userState";
+import useSetUserInfoToLocalStorage from "../../../utils/customHooks/useSetUser";
 
 interface IAdminLoadingAndGetUserProps {}
 
 const AdminLoadingAndGetUser = () => {
   const navigate = useNavigate();
   const [isUser, setIsUser] = useRecoilState(userState);
+  const { setUser } = useSetUserInfoToLocalStorage();
   const { isSuccess, isRefetching } = useMeQuery<MeQuery, Error>(
     graphqlReqeustClient(isUser.accessToken),
     undefined,
@@ -23,11 +26,12 @@ const AdminLoadingAndGetUser = () => {
 
   useEffect(() => {
     if (isSuccess && !isRefetching) {
-      navigate(`/admin/${isUser.id}/store`);
+      setUser(isUser);
+      setTimeout(() => navigate(`/admin/${isUser.id}/store`), 3000);
     }
-  }, [isSuccess, isRefetching]);
+  }, [isSuccess, isRefetching, isUser]);
 
-  return <div>로딩중입니다.</div>;
+  return <Loading title="로그인 중입니다." subTitle="잠시만 기다려주세요." />;
 };
 
 export default AdminLoadingAndGetUser;

--- a/src/Page/Admin/Login/AdminLoadingAndGetUser.tsx
+++ b/src/Page/Admin/Login/AdminLoadingAndGetUser.tsx
@@ -1,0 +1,33 @@
+import React, { useEffect } from "react";
+import { useNavigate } from "react-router-dom";
+import { useRecoilState } from "recoil";
+import { MeQuery, useMeQuery } from "../../../generated/graphql";
+import graphqlReqeustClient from "../../../lib/graphqlRequestClient";
+import { userState } from "../../../state/userState";
+
+interface IAdminLoadingAndGetUserProps {}
+
+const AdminLoadingAndGetUser = () => {
+  const navigate = useNavigate();
+  const [isUser, setIsUser] = useRecoilState(userState);
+  const { isSuccess, isRefetching } = useMeQuery<MeQuery, Error>(
+    graphqlReqeustClient(isUser.accessToken),
+    undefined,
+    {
+      onSuccess: (data) => {
+        const { id, email, name } = data.me;
+        setIsUser((pre) => ({ ...pre, id, email, name }));
+      },
+    },
+  );
+
+  useEffect(() => {
+    if (isSuccess && !isRefetching) {
+      navigate(`/admin/${isUser.id}/store`);
+    }
+  }, [isSuccess, isRefetching]);
+
+  return <div>로딩중입니다.</div>;
+};
+
+export default AdminLoadingAndGetUser;

--- a/src/Page/Admin/Login/AdminLogin.tsx
+++ b/src/Page/Admin/Login/AdminLogin.tsx
@@ -14,14 +14,11 @@ import graphqlReqeustClient from "../../../lib/graphqlRequestClient";
 import { handleErrorMessage } from "../../../utils/helper/handleErrorMessage";
 import { useQueryClient } from "react-query";
 import AdminLoadingAndGetUser from "./AdminLoadingAndGetUser";
+import PageHeaderMessage from "../../../Components/PageHeader";
 
 const Wrapper = styled.div`
   height: 80vh;
   overflow: hidden;
-`;
-
-const Title = styled.h2`
-  ${Headline2};
 `;
 
 const FormContainer = styled.div`
@@ -156,7 +153,7 @@ const AdminMain = () => {
 
   return !isUser.isLogin ? (
     <Wrapper>
-      <Title>관리자 로그인 화면</Title>
+      <PageHeaderMessage header="로그인" />
       <FormContainer>
         <form onSubmit={onSubmit}>
           <LoginLabel htmlFor="email">이메일</LoginLabel>

--- a/src/Page/Admin/Logout.tsx
+++ b/src/Page/Admin/Logout.tsx
@@ -1,0 +1,37 @@
+import React, { useEffect } from "react";
+import { useNavigate } from "react-router-dom";
+import { useSetRecoilState } from "recoil";
+import Loading from "../../Components/Loading";
+import { userState } from "../../state/userState";
+import useRemoveUserInfoInLocalStorage from "../../utils/customHooks/useRemoveUserInfoInLocalStorage";
+
+interface ILogoutProps {}
+
+const Logout = () => {
+  const navigate = useNavigate();
+  const setUserInfo = useSetRecoilState(userState);
+  const { removeUser } = useRemoveUserInfoInLocalStorage();
+
+  useEffect(() => {
+    setUserInfo({
+      isLogin: false,
+      id: undefined,
+      email: undefined,
+      name: undefined,
+      accessToken: undefined,
+      refreshToken: undefined,
+    });
+    removeUser("user");
+
+    setTimeout(() => navigate("/"), 3000);
+  }, []);
+
+  return (
+    <Loading
+      title="로그아웃 중입니다."
+      subTitle="오늘 하루 수고한 나 치맥이닷!"
+    />
+  );
+};
+
+export default Logout;

--- a/src/Page/Admin/Logout.tsx
+++ b/src/Page/Admin/Logout.tsx
@@ -21,7 +21,7 @@ const Logout = () => {
       accessToken: undefined,
       refreshToken: undefined,
     });
-    removeUser("user");
+    removeUser("kiosk-user");
 
     setTimeout(() => navigate("/"), 3000);
   }, []);

--- a/src/Page/Landing/LandingMain.tsx
+++ b/src/Page/Landing/LandingMain.tsx
@@ -63,12 +63,10 @@ const LandingMain = () => {
         <h1>누구나 키오스크</h1>
         <Title>누구나 쉽고 빠르게 내 가게를 운영하는 방법</Title>
         <div>
-          <LinkButton onClick={() => navigate("/landing/agreement")}>
+          <LinkButton onClick={() => navigate("/agreement")}>
             회원가입
           </LinkButton>
-          <LinkButton onClick={() => navigate("/admin/login")}>
-            로그인
-          </LinkButton>
+          <LinkButton onClick={() => navigate("/login")}>로그인</LinkButton>
         </div>
       </Container>
     </Wrapper>

--- a/src/Routers/Routers.tsx
+++ b/src/Routers/Routers.tsx
@@ -1,6 +1,6 @@
-import React from "react";
+import React, { useState } from "react";
 import { Routes, Route, Navigate } from "react-router-dom";
-import AdminLogin from "../Page/Admin/Login/AdminLogin";
+import Login from "../Page/Admin/Login/AdminLogin";
 import AdminManageProductAddItem from "../Page/Admin/AdminManageProductAddItem";
 import AdminManageProductItemList from "../Page/Admin/AdminManageProductItemList";
 import AdminMain from "../Page/Admin/AdminMain";
@@ -17,47 +17,53 @@ import Agreement from "../Page/Landing/Agreement";
 import AdminStoreList from "../Page/Admin/Store/AdminStoreList";
 import AdminCreateStore from "../Page/Admin/Store/AdminCreateStore";
 import AdminUpdateStore from "../Page/Admin/Store/AdminUpdateStore";
+import { useRecoilValue } from "recoil";
+import { userState } from "../state/userState";
+import Logout from "../Page/Admin/Logout";
 
 const Router = () => {
+  const { isLogin } = useRecoilValue(userState);
+
   return (
     <Routes>
-      <Route path="/admin" element={<AdminLayout />}>
-        <Route path="login" element={<AdminLogin />} />
-        <Route path=":id">
-          <Route path="store">
-            <Route path="" element={<Navigate to="list" />} />
-            <Route path="list" element={<AdminStoreList />} />
-            <Route path="create" element={<AdminCreateStore />} />
-            <Route path="update" element={<AdminUpdateStore />} />
+      {isLogin && (
+        <>
+          <Route path="/admin" element={<AdminLayout />}>
             <Route path=":id">
-              <Route path="main" element={<AdminMain />} />
-              <Route
-                path="manage-product"
-                element={<AdminManageProductItemList />}
-              />
-              <Route
-                path="add-product"
-                element={<AdminManageProductAddItem />}
-              />
-              <Route path="manage-order" element={<MangeOrderMain />} />
+              <Route path="store">
+                <Route path="" element={<Navigate to="list" />} />
+                <Route path="list" element={<AdminStoreList />} />
+                <Route path="create" element={<AdminCreateStore />} />
+                <Route path="update" element={<AdminUpdateStore />} />
+                <Route path=":id">
+                  <Route path="main" element={<AdminMain />} />
+                  <Route
+                    path="manage-product"
+                    element={<AdminManageProductItemList />}
+                  />
+                  <Route
+                    path="add-product"
+                    element={<AdminManageProductAddItem />}
+                  />
+                  <Route path="manage-order" element={<MangeOrderMain />} />
+                </Route>
+              </Route>
             </Route>
           </Route>
-        </Route>
-      </Route>
-      <Route path="/order" />
-      <Route path="/client" element={<ClientLayout />}>
-        <Route path="" element={<Navigate to="/client/main" />} />
-        <Route path="main" element={<ClientMain />} />
-        <Route path="menu" element={<ClientMenu />} />
-        <Route path="select-list" element={<ClientSelectList />} />
-      </Route>
-
-      <Route path="" element={<Navigate to="/landing/main" />} />
-      <Route path="/landing">
-        <Route path="" element={<Navigate to="/landing/main" />} />
-        <Route path="main" element={<LandingMain />} />
+          <Route path="/client" element={<ClientLayout />}>
+            <Route path="" element={<Navigate to="/client/main" />} />
+            <Route path="main" element={<ClientMain />} />
+            <Route path="menu" element={<ClientMenu />} />
+            <Route path="select-list" element={<ClientSelectList />} />
+          </Route>
+        </>
+      )}
+      <Route path="/" element={<ClientLayout />}>
+        <Route path="/" element={<LandingMain />} />
         <Route path="agreement" element={<Agreement />} />
         <Route path="signup" element={<SignUp />} />
+        <Route path="login" element={<Login />} />
+        <Route path="logout" element={<Logout />} />
       </Route>
       <Route path="*" element={<PageNotFound />} />
     </Routes>

--- a/src/Routers/Routers.tsx
+++ b/src/Routers/Routers.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { Routes, Route, Navigate } from "react-router-dom";
-import AdminLogin from "../Page/Admin/AdminLogin";
+import AdminLogin from "../Page/Admin/Login/AdminLogin";
 import AdminManageProductAddItem from "../Page/Admin/AdminManageProductAddItem";
 import AdminManageProductItemList from "../Page/Admin/AdminManageProductItemList";
 import AdminMain from "../Page/Admin/AdminMain";
@@ -14,9 +14,9 @@ import ClientSelectList from "../Page/Client/ClientSelectList";
 import LandingMain from "../Page/Landing/LandingMain";
 import SignUp from "../Page/Landing/SignUp";
 import Agreement from "../Page/Landing/Agreement";
-import AdminStoreList from "../Page/Admin/AdminStoreList";
-import AdminCreateStore from "../Page/Admin/AdminCreateStore";
-import AdminUpdateStore from "../Page/Admin/AdminUpdateStore";
+import AdminStoreList from "../Page/Admin/Store/AdminStoreList";
+import AdminCreateStore from "../Page/Admin/Store/AdminCreateStore";
+import AdminUpdateStore from "../Page/Admin/Store/AdminUpdateStore";
 
 const Router = () => {
   return (

--- a/src/generated/graphql.ts
+++ b/src/generated/graphql.ts
@@ -1,5 +1,11 @@
 import { GraphQLClient } from "graphql-request";
-import { useMutation, UseMutationOptions } from "react-query";
+import { RequestInit } from "graphql-request/dist/types.dom";
+import {
+  useQuery,
+  useMutation,
+  UseQueryOptions,
+  UseMutationOptions,
+} from "react-query";
 export type Maybe<T> = T | null;
 export type InputMaybe<T> = Maybe<T>;
 export type Exact<T extends { [key: string]: unknown }> = {
@@ -165,6 +171,7 @@ export type Product = {
 
 export type Query = {
   __typename?: "Query";
+  me: User;
   orders: Array<Order>;
   store?: Maybe<Store>;
   stores: Array<Maybe<Store>>;
@@ -219,6 +226,18 @@ export type RemoveProductOptionInput = {
   OptionIds: Array<Scalars["Int"]>;
 };
 
+export type StoreQueryVariables = Exact<{
+  id: Scalars["Float"];
+}>;
+
+export type StoreQuery = {
+  __typename?: "Query";
+  store?: {
+    __typename?: "Store";
+    products: Array<{ __typename?: "Product"; name: string }>;
+  } | null;
+};
+
 export type LoginMutationVariables = Exact<{
   email: Scalars["String"];
   password: Scalars["String"];
@@ -233,6 +252,38 @@ export type LoginMutation = {
   };
 };
 
+export type MeQueryVariables = Exact<{ [key: string]: never }>;
+
+export type MeQuery = {
+  __typename?: "Query";
+  me: { __typename?: "User"; id: string; name: string; email: string };
+};
+
+export const StoreDocument = `
+    query store($id: Float!) {
+  store(id: $id) {
+    products {
+      name
+    }
+  }
+}
+    `;
+export const useStoreQuery = <TData = StoreQuery, TError = unknown>(
+  client: GraphQLClient,
+  variables: StoreQueryVariables,
+  options?: UseQueryOptions<StoreQuery, TError, TData>,
+  headers?: RequestInit["headers"],
+) =>
+  useQuery<StoreQuery, TError, TData>(
+    ["store", variables],
+    fetcher<StoreQuery, StoreQueryVariables>(
+      client,
+      StoreDocument,
+      variables,
+      headers,
+    ),
+    options,
+  );
 export const LoginDocument = `
     mutation login($email: String!, $password: String!) {
   login(email: $email, password: $password) {
@@ -260,5 +311,27 @@ export const useLoginMutation = <TError = unknown, TContext = unknown>(
         variables,
         headers,
       )(),
+    options,
+  );
+
+export const MeDocument = `
+    query me {
+  me {
+    id
+    name
+    email
+  }
+}
+    `;
+
+export const useMeQuery = <TData = MeQuery, TError = unknown>(
+  client: GraphQLClient,
+  variables?: MeQueryVariables,
+  options?: UseQueryOptions<MeQuery, TError, TData>,
+  headers?: RequestInit["headers"],
+) =>
+  useQuery<MeQuery, TError, TData>(
+    variables === undefined ? ["me"] : ["me", variables],
+    fetcher<MeQuery, MeQueryVariables>(client, MeDocument, variables, headers),
     options,
   );

--- a/src/graphql/user.graphql
+++ b/src/graphql/user.graphql
@@ -4,3 +4,11 @@ mutation login($email: String!, $password: String!) {
     refreshToken
   }
 }
+
+query me {
+  me {
+    id
+    name
+    email
+  }
+}

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -6,6 +6,7 @@ import { theme } from "./theme";
 import { GlobalStyle } from "./GlobalStyle";
 import App from "./App";
 import { QueryClientProvider, QueryClient } from "react-query";
+import { ReactQueryDevtools } from "react-query/devtools";
 
 const queryClient = new QueryClient();
 
@@ -16,6 +17,7 @@ ReactDOM.render(
         <ThemeProvider theme={theme}>
           <GlobalStyle />
           <App />
+          <ReactQueryDevtools initialIsOpen={false} />
         </ThemeProvider>
       </RecoilRoot>
     </QueryClientProvider>

--- a/src/lib/graphqlRequestClient.ts
+++ b/src/lib/graphqlRequestClient.ts
@@ -1,5 +1,12 @@
 import { GraphQLClient } from "graphql-request";
 
-const graphqlReqeustClient = new GraphQLClient("http://kyojs.com:3200/graphql");
+const graphqlReqeustClient = (token?: string) =>
+  token
+    ? new GraphQLClient("http://kyojs.com:3200/graphql", {
+        headers: {
+          authorization: `Bearer ${token}`,
+        },
+      })
+    : new GraphQLClient("http://kyojs.com:3200/graphql");
 
 export default graphqlReqeustClient;

--- a/src/state/userState.ts
+++ b/src/state/userState.ts
@@ -1,6 +1,6 @@
 import { atom } from "recoil";
 
-interface UserState {
+export interface UserState {
   id: string | undefined;
   name: string | undefined;
   email: string | undefined;

--- a/src/state/userState.ts
+++ b/src/state/userState.ts
@@ -1,10 +1,22 @@
 import { atom } from "recoil";
 
 interface UserState {
-  login: boolean;
+  id: string | undefined;
+  name: string | undefined;
+  email: string | undefined;
+  isLogin: boolean;
+  accessToken: string | undefined;
+  refreshToken: string | undefined;
 }
 
 export const userState = atom<UserState>({
   key: "user",
-  default: { login: false },
+  default: {
+    isLogin: false,
+    id: undefined,
+    name: undefined,
+    email: undefined,
+    accessToken: undefined,
+    refreshToken: undefined,
+  },
 });

--- a/src/utils/customHooks/useGetUserStateFromLocalStorage.tsx
+++ b/src/utils/customHooks/useGetUserStateFromLocalStorage.tsx
@@ -5,7 +5,7 @@ interface IuseGetUserStateFromLocalStorageProps {}
 
 const useGetUserInfoFromLocalStorage = () => {
   const getUser = () => {
-    const user = localStorage.getItem("user");
+    const user = localStorage.getItem("kioks-user");
 
     if (user) {
       return JSON.parse(user) as UserState;

--- a/src/utils/customHooks/useGetUserStateFromLocalStorage.tsx
+++ b/src/utils/customHooks/useGetUserStateFromLocalStorage.tsx
@@ -1,0 +1,20 @@
+import React from "react";
+import { UserState } from "../../state/userState";
+
+interface IuseGetUserStateFromLocalStorageProps {}
+
+const useGetUserInfoFromLocalStorage = () => {
+  const getUser = () => {
+    const user = localStorage.getItem("user");
+
+    if (user) {
+      return JSON.parse(user) as UserState;
+    }
+
+    return undefined;
+  };
+
+  return { getUser };
+};
+
+export default useGetUserInfoFromLocalStorage;

--- a/src/utils/customHooks/useRemoveUserInfoInLocalStorage.tsx
+++ b/src/utils/customHooks/useRemoveUserInfoInLocalStorage.tsx
@@ -1,0 +1,12 @@
+import React from "react";
+
+interface IuseRemoveUserInfoInLocalStorageProps {}
+
+const useRemoveUserInfoInLocalStorage = () => {
+  const removeUser = (key: string) => {
+    localStorage.removeItem(key);
+  };
+  return { removeUser };
+};
+
+export default useRemoveUserInfoInLocalStorage;

--- a/src/utils/customHooks/useSetUser.tsx
+++ b/src/utils/customHooks/useSetUser.tsx
@@ -1,0 +1,15 @@
+import React from "react";
+import { useRecoilValue } from "recoil";
+
+import { userState, UserState } from "../../state/userState";
+
+interface IuseSetUserInfoToLocalStroageProps {}
+
+const useSetUserInfoToLocalStorage = () => {
+  const setUser = (user: UserState) => {
+    localStorage.setItem("user", JSON.stringify(user));
+  };
+  return { setUser };
+};
+
+export default useSetUserInfoToLocalStorage;

--- a/src/utils/customHooks/useSetUser.tsx
+++ b/src/utils/customHooks/useSetUser.tsx
@@ -7,7 +7,7 @@ interface IuseSetUserInfoToLocalStroageProps {}
 
 const useSetUserInfoToLocalStorage = () => {
   const setUser = (user: UserState) => {
-    localStorage.setItem("user", JSON.stringify(user));
+    localStorage.setItem("kiosk-user", JSON.stringify(user));
   };
   return { setUser };
 };


### PR DESCRIPTION
# 개요
로그인 코드 작성

# 작업 내용
AdminLogin에서 mutation이 성공하면 AdminLoadingAndGetUser 컴포넌트가 로딩되고 유저 정보를 전부 불러오면 store로 redirect한다.
개요
로그인 후에 유저가 새로고침을 해도 로그인 상태를 유지하도록 로직 추가
로그아웃 버튼을 누르면 로그인 할때 저장한 유저 정보 삭제
App.tsx
- 로컬스토리지에 사용자 정보가 저장된 경우에 새로고침을 할 경우 다시 atom에 사용자 정보를 저장하는 로직 추가
Page
    AdminLoadingAndGetUser
    - 로그인 성공시에 받은 jwt 토큰을 사용해 유저 정보를 서버에 요청하고 로컬 스토리지와 atom에 저장하는 역할을 한다.
    - 성공 했을 경우에만 store로 리다이렉트된다.
    AdminLogin.tsx
    - 로그인 화면
    - login mutation을 성공하면 AdminLoadingAndGetUser 컴포넌트를 불러온다.
    Logout.tsx
    - 로그아웃. 저장된 사용자 정보를 전부 삭제한다.
    LandingMain.tsx
    - login 버튼 링크 변경
Routers
    - admin과 client는 로그인에 성공했을 때만 접근 가능하도록 수정하였다.
utils/customHooks
    useGetUserStateFromLocalStorage
    -로컬스토리지에 저장된 사용자 정보를 불러오는 역할을 한다.
    useRemoveUserInfoInLocalStorage
    -로컬스토리지에 저장된 사용자 정보를 지우는 역할을 한다.
    useSetUser
    -로컬스토리지에 사용자 정보를 저장하는 역할을 한다.
Layouts
    AdminLayout.tsx
    - 로그인에 성공했을 경우 nav 태그가 보이도록 변경
Components
    PageHeader.tsx
    - 메인 타이틀 아래 서브 타이틀 컴포넌트
    - 스타일 통일을 위해서 만들었다. 메인 타이틀 아래 서브 타이틀은 컴포넌트를 사용해서 수정하기.
    Loading.tsx
    - 로딩 화면
    ButtonDefault.tsx
    - children의 타입을 ReactNode로 수정


기타 : 백앤드에서 프론트로 오는 에러 메시지가 일관되지 않습니다. 이 부분 수정이 필요합니다.

# 스크린샷 
필요하다면 첨부해주세요.
