### PR TITLE
Feature/admin-store Create Store 구현

### DIFF
--- a/src/Page/Admin/Store/AdminCreateStore.tsx
+++ b/src/Page/Admin/Store/AdminCreateStore.tsx
@@ -1,0 +1,217 @@
+import React, { useEffect, useState } from "react";
+import { useForm } from "react-hook-form";
+import { useQueryClient } from "react-query";
+import { useNavigate, useParams } from "react-router-dom";
+import { useRecoilValue } from "recoil";
+import styled from "styled-components";
+import InputDefault from "../../../Components/Form/InputDefault";
+import LabelDefault from "../../../Components/Form/LabelDefault";
+import Loading from "../../../Components/Loading";
+import { useAddStoreMutation } from "../../../generated/graphql";
+import graphqlReqeustClient from "../../../lib/graphqlRequestClient";
+import { ErrorState } from "../../../lib/interface";
+import { SubTitle1, SubTitle2 } from "../../../mixin";
+import { userState } from "../../../state/userState";
+import { handleErrorMessage } from "../../../utils/helper/handleErrorMessage";
+
+const Form = styled.form`
+  width: 100%;
+`;
+const InputContainer = styled.div`
+  display: grid;
+  border-bottom: 1px solid ${(props) => props.theme.color.gray300};
+  grid-template-columns: repeat(auto-fill, minmax(20%, auto));
+  label {
+    grid-column: 1 / 2;
+    ${SubTitle1};
+  }
+  input {
+    grid-column: 2 / 10;
+    ${SubTitle2};
+    border: unset;
+    outline: unset;
+  }
+  .error-label {
+    grid-column: 2 / 10;
+    ${SubTitle2};
+    color: ${(props) => props.theme.color.error500};
+  }
+`;
+
+const StatusBar = styled.div`
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  padding: 0 1rem;
+  height: 5rem;
+
+  .status-bar-item-container {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    height: 100%;
+    border-top: 1px solid ${(props) => props.theme.color.gray300};
+  }
+  .status-message-container {
+    h2 {
+      font-size: 2rem;
+      font-weight: bold;
+      color: ${(props) => props.theme.color.fontColorBlack};
+    }
+  }
+  .status-button-container {
+    button {
+      cursor: pointer;
+      padding: 0.5rem 1.8rem;
+      border: 0;
+      font-size: 2rem;
+      color: ${(props) => props.theme.color.fontColorWhite};
+      border-radius: 0.2rem;
+      line-height: 2.8rem;
+    }
+
+    .cancel-button {
+      background-color: ${(props) => props.theme.color.gray300};
+    }
+    .confirm-button {
+      margin-left: 0.5rem;
+      background-color: ${(props) => props.theme.color.primary700};
+    }
+  }
+`;
+
+interface IAdminStoreProps {}
+interface IStoreFormProps {
+  name: string;
+  code: string;
+  phone: string;
+  address: string;
+  addFail?: string;
+}
+
+const AdminStore = () => {
+  const id = useParams();
+  const navigate = useNavigate();
+  const [isLoading, setIsLoading] = useState(false);
+  const [errorState, setErrorState] = useState<ErrorState>();
+  const { accessToken } = useRecoilValue(userState);
+  const queryClient = useQueryClient();
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+    setError,
+  } = useForm<IStoreFormProps>();
+
+  const { mutate, data, isSuccess } = useAddStoreMutation<Error>(
+    graphqlReqeustClient(accessToken),
+    {
+      onSuccess: () => {
+        queryClient.invalidateQueries("stores");
+      },
+      onError: (error) => {
+        handleErrorMessage(error, setErrorState);
+        if (errorState) {
+          const [message] = errorState?.response.errors;
+          const error = message.extensions.exception.response.error;
+          setError("addFail", { message: error });
+        }
+      },
+    },
+  );
+
+  const onSubmit = handleSubmit((data) => {
+    mutate({ ...data });
+    setIsLoading(true);
+  });
+
+  useEffect(() => {
+    let time: NodeJS.Timeout;
+    if (isSuccess && data.addStore) {
+      time = setTimeout(() => {
+        setIsLoading(false);
+        navigate(`/admin/${id}/store`);
+      }, 3000);
+    }
+    return () => time && clearTimeout(time);
+  }, [isSuccess, data]);
+
+  return (
+    <>
+      {isLoading && (
+        <Loading
+          title="가게를 등록 하고있어요."
+          subTitle="첫 가게를 등록하신 것을 축하드립니다 🎉"
+        />
+      )}
+      <Form onSubmit={onSubmit}>
+        <InputContainer>
+          <LabelDefault htmlFor="code">사업자번호</LabelDefault>
+          <InputDefault
+            id="code"
+            name="code"
+            placeholder="사업자 번호를 입력해주세요."
+            register={register}
+            registerOptions={{ required: "사업자 번호가 꼭 필요해요." }}
+            error={errors.code?.message}
+          />
+        </InputContainer>
+        <InputContainer>
+          <LabelDefault htmlFor="name">가게이름</LabelDefault>
+          <InputDefault
+            id="name"
+            name="name"
+            placeholder="가게 이름을 입력해주세요."
+            register={register}
+            registerOptions={{ required: "가게 이름이 꼭 있어야합니다." }}
+            error={errors.name?.message}
+          />
+        </InputContainer>
+        <InputContainer>
+          <LabelDefault htmlFor="address">주소</LabelDefault>
+          <InputDefault
+            id="address"
+            name="address"
+            placeholder="주소를 입력해주세요."
+            register={register}
+            registerOptions={{ required: "주소가 꼭 있어야합니다." }}
+            error={errors.address?.message}
+          />
+        </InputContainer>
+        <InputContainer>
+          <LabelDefault htmlFor="phone">전화번호</LabelDefault>
+          <InputDefault
+            id="phone"
+            name="phone"
+            placeholder="가게 대표 번호를 입력해주세요."
+            register={register}
+            registerOptions={{ required: "대표 번호가 꼭 필요합니다." }}
+            error={errors.phone?.message}
+          />
+        </InputContainer>
+        <input style={{ visibility: "hidden" }} type="submit" />
+      </Form>
+      <LabelDefault className="error-label">
+        {errors.addFail?.message}
+      </LabelDefault>
+      <StatusBar>
+        <div className="status-bar-item-container">
+          <div className="status-message-container">
+            <h2>입력이 끝나면 등록하기 버튼을 눌러주세요.</h2>
+          </div>
+          <div className="status-button-container">
+            <button onClick={() => navigate(-1)} className="cancel-button">
+              돌아가기
+            </button>
+            <button onClick={onSubmit} className="confirm-button">
+              등록하기
+            </button>
+          </div>
+        </div>
+      </StatusBar>
+    </>
+  );
+};
+
+export default AdminStore;

--- a/src/Page/Admin/Store/AdminStoreList.tsx
+++ b/src/Page/Admin/Store/AdminStoreList.tsx
@@ -1,0 +1,47 @@
+import React, { useEffect, useMemo } from "react";
+import styled from "styled-components";
+import PageHeaderMessage from "../../../Components/PageHeader";
+import ButtonDefaultStyle from "../../../Components/Buttons/ButtonDefault";
+import { MdAddCircle } from "react-icons/md";
+import { Link } from "react-router-dom";
+import { useRecoilValue } from "recoil";
+import { userState } from "../../../state/userState";
+
+interface IAdminStoreListProps {}
+
+const Wrapper = styled.div``;
+const Header = styled.div`
+  display: flex;
+  justify-content: space-between;
+`;
+
+const AddStoreButton = styled(ButtonDefaultStyle)`
+  display: flex;
+  align-items: center;
+  color: ${(props) => props.theme.color.fontColorBlack};
+  background-color: unset;
+  span {
+    margin-left: 0.5rem;
+  }
+`;
+
+const AdminStoreList = () => {
+  const user = useRecoilValue(userState);
+
+  return (
+    <Wrapper>
+      <Header>
+        <PageHeaderMessage
+          header="가게목록"
+          message="아직 등록된 가게가 없습니다."
+        />
+        <AddStoreButton>
+          <MdAddCircle />
+          <Link to={`/admin/${user.id}/store/create`}>가게등록</Link>
+        </AddStoreButton>
+      </Header>
+    </Wrapper>
+  );
+};
+
+export default AdminStoreList;

--- a/src/Page/Admin/Store/AdminUpdateStore.tsx
+++ b/src/Page/Admin/Store/AdminUpdateStore.tsx
@@ -1,0 +1,9 @@
+import React from "react";
+
+interface IAdminUpdateStoreProps {}
+
+const AdminUpdateStore = () => {
+  return <div>AdminUpdateStore</div>;
+};
+
+export default AdminUpdateStore;

--- a/src/Routers/Routers.tsx
+++ b/src/Routers/Routers.tsx
@@ -29,13 +29,13 @@ const Router = () => {
       {isLogin && (
         <>
           <Route path="/admin" element={<AdminLayout />}>
-            <Route path=":id">
+            <Route path=":userId">
               <Route path="store">
                 <Route path="" element={<Navigate to="list" />} />
                 <Route path="list" element={<AdminStoreList />} />
                 <Route path="create" element={<AdminCreateStore />} />
                 <Route path="update" element={<AdminUpdateStore />} />
-                <Route path=":id">
+                <Route path=":storeId">
                   <Route path="main" element={<AdminMain />} />
                   <Route
                     path="manage-product"

--- a/src/generated/graphql.ts
+++ b/src/generated/graphql.ts
@@ -1,31 +1,14 @@
-import { GraphQLClient } from "graphql-request";
-import { RequestInit } from "graphql-request/dist/types.dom";
-import {
-  useQuery,
-  useMutation,
-  UseQueryOptions,
-  UseMutationOptions,
-} from "react-query";
+import { GraphQLClient } from 'graphql-request';
+import { RequestInit } from 'graphql-request/dist/types.dom';
+import { useQuery, useMutation, UseQueryOptions, UseMutationOptions } from 'react-query';
 export type Maybe<T> = T | null;
 export type InputMaybe<T> = Maybe<T>;
-export type Exact<T extends { [key: string]: unknown }> = {
-  [K in keyof T]: T[K];
-};
-export type MakeOptional<T, K extends keyof T> = Omit<T, K> & {
-  [SubKey in K]?: Maybe<T[SubKey]>;
-};
-export type MakeMaybe<T, K extends keyof T> = Omit<T, K> & {
-  [SubKey in K]: Maybe<T[SubKey]>;
-};
+export type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
+export type MakeOptional<T, K extends keyof T> = Omit<T, K> & { [SubKey in K]?: Maybe<T[SubKey]> };
+export type MakeMaybe<T, K extends keyof T> = Omit<T, K> & { [SubKey in K]: Maybe<T[SubKey]> };
 
-function fetcher<TData, TVariables>(
-  client: GraphQLClient,
-  query: string,
-  variables?: TVariables,
-  headers?: RequestInit["headers"],
-) {
-  return async (): Promise<TData> =>
-    client.request<TData, TVariables>(query, variables, headers);
+function fetcher<TData, TVariables>(client: GraphQLClient, query: string, variables?: TVariables, headers?: RequestInit['headers']) {
+  return async (): Promise<TData> => client.request<TData, TVariables>(query, variables, headers);
 }
 /** All built-in and custom scalars, mapped to their actual values */
 export type Scalars = {
@@ -37,140 +20,152 @@ export type Scalars = {
 };
 
 export type AddProductInput = {
-  description?: InputMaybe<Scalars["String"]>;
-  imageUrl?: InputMaybe<Scalars["String"]>;
-  name: Scalars["String"];
-  price: Scalars["Int"];
-  storeId: Scalars["Int"];
+  description?: InputMaybe<Scalars['String']>;
+  imageUrl?: InputMaybe<Scalars['String']>;
+  name: Scalars['String'];
+  price: Scalars['Int'];
+  storeId: Scalars['Int'];
 };
 
 export type AddProductOptionInput = {
-  name: Scalars["String"];
-  productId: Scalars["Int"];
+  name: Scalars['String'];
+  productId: Scalars['Int'];
 };
 
 export type AddStoreInput = {
-  address: Scalars["String"];
-  code: Scalars["String"];
-  name: Scalars["String"];
-  phone: Scalars["String"];
+  address: Scalars['String'];
+  code: Scalars['String'];
+  name: Scalars['String'];
+  phone: Scalars['String'];
 };
 
 export type AddUserInput = {
-  email: Scalars["String"];
-  name: Scalars["String"];
-  password: Scalars["String"];
+  email: Scalars['String'];
+  name: Scalars['String'];
+  password: Scalars['String'];
 };
 
 export type EditProductInput = {
-  description?: InputMaybe<Scalars["String"]>;
-  imageUrl?: InputMaybe<Scalars["String"]>;
-  name?: InputMaybe<Scalars["String"]>;
-  price?: InputMaybe<Scalars["Int"]>;
-  productId: Scalars["Int"];
+  description?: InputMaybe<Scalars['String']>;
+  imageUrl?: InputMaybe<Scalars['String']>;
+  name?: InputMaybe<Scalars['String']>;
+  price?: InputMaybe<Scalars['Int']>;
+  productId: Scalars['Int'];
 };
 
 export type EditProductOptionInput = {
-  name: Scalars["String"];
-  optionId: Scalars["Int"];
+  name: Scalars['String'];
+  optionId: Scalars['Int'];
 };
 
 export type Mutation = {
-  __typename?: "Mutation";
-  addProductOptions: Scalars["Boolean"];
-  addProducts: Scalars["Boolean"];
-  addStore: Scalars["Boolean"];
-  addUser: Scalars["Boolean"];
+  __typename?: 'Mutation';
+  addProductOptions: Scalars['Boolean'];
+  addProducts: Scalars['Boolean'];
+  addStore: Scalars['Boolean'];
+  addUser: Scalars['Boolean'];
   login: TokenOutput;
-  removeProductOptions: Scalars["Boolean"];
-  removeProducts: Scalars["Boolean"];
-  removeStore: Scalars["Boolean"];
+  removeProductOptions: Scalars['Boolean'];
+  removeProducts: Scalars['Boolean'];
+  removeStore: Scalars['Boolean'];
   signup: TokenOutput;
-  updateProduct: Scalars["Boolean"];
-  updateProductOption: Scalars["Boolean"];
-  updateUser: Scalars["Boolean"];
-  withdraw: Scalars["Boolean"];
+  updateProduct: Scalars['Boolean'];
+  updateProductOption: Scalars['Boolean'];
+  updateUser: Scalars['Boolean'];
+  withdraw: Scalars['Boolean'];
 };
+
 
 export type MutationAddProductOptionsArgs = {
   option: Array<AddProductOptionInput>;
 };
 
+
 export type MutationAddProductsArgs = {
   products: Array<AddProductInput>;
 };
+
 
 export type MutationAddStoreArgs = {
   store: AddStoreInput;
 };
 
+
 export type MutationAddUserArgs = {
   user: AddUserInput;
 };
 
+
 export type MutationLoginArgs = {
-  email: Scalars["String"];
-  password: Scalars["String"];
+  email: Scalars['String'];
+  password: Scalars['String'];
 };
+
 
 export type MutationRemoveProductOptionsArgs = {
   optionIds: RemoveProductOptionInput;
 };
 
+
 export type MutationRemoveProductsArgs = {
   productIds: RemoveProductInput;
 };
 
+
 export type MutationRemoveStoreArgs = {
-  id: Scalars["Float"];
+  id: Scalars['Float'];
 };
+
 
 export type MutationSignupArgs = {
   user: SignupInput;
 };
 
+
 export type MutationUpdateProductArgs = {
   products: EditProductInput;
 };
+
 
 export type MutationUpdateProductOptionArgs = {
   option: EditProductOptionInput;
 };
 
+
 export type MutationUpdateUserArgs = {
-  name: Scalars["String"];
-  userId: Scalars["Int"];
+  name: Scalars['String'];
+  userId: Scalars['Int'];
 };
 
 export type Option = {
-  __typename?: "Option";
-  id: Scalars["ID"];
-  name: Scalars["String"];
-  productId: Scalars["Int"];
+  __typename?: 'Option';
+  id: Scalars['ID'];
+  name: Scalars['String'];
+  productId: Scalars['Int'];
 };
 
 export type Order = {
-  __typename?: "Order";
-  id: Scalars["ID"];
-  number: Scalars["Int"];
-  price: Scalars["Int"];
+  __typename?: 'Order';
+  id: Scalars['ID'];
+  number: Scalars['Int'];
+  price: Scalars['Int'];
   products: Array<Product>;
-  storeId: Scalars["Int"];
+  storeId: Scalars['Int'];
 };
 
 export type Product = {
-  __typename?: "Product";
-  description?: Maybe<Scalars["String"]>;
-  id: Scalars["ID"];
-  imageUrl?: Maybe<Scalars["String"]>;
-  name: Scalars["String"];
+  __typename?: 'Product';
+  description?: Maybe<Scalars['String']>;
+  id: Scalars['ID'];
+  imageUrl?: Maybe<Scalars['String']>;
+  name: Scalars['String'];
   options: Array<Option>;
-  price: Scalars["Int"];
-  storeId: Scalars["Int"];
+  price: Scalars['Int'];
+  storeId: Scalars['Int'];
 };
 
 export type Query = {
-  __typename?: "Query";
+  __typename?: 'Query';
   me: User;
   orders: Array<Order>;
   store?: Maybe<Store>;
@@ -178,86 +173,86 @@ export type Query = {
   users: Array<Maybe<User>>;
 };
 
+
 export type QueryOrdersArgs = {
-  limit?: InputMaybe<Scalars["Int"]>;
-  offset?: InputMaybe<Scalars["Int"]>;
-  storeId: Scalars["Int"];
+  limit?: InputMaybe<Scalars['Int']>;
+  offset?: InputMaybe<Scalars['Int']>;
+  storeId: Scalars['Int'];
 };
 
+
 export type QueryStoreArgs = {
-  id: Scalars["Float"];
+  id: Scalars['Float'];
 };
 
 export type SignupInput = {
-  email: Scalars["String"];
-  name: Scalars["String"];
-  password: Scalars["String"];
+  email: Scalars['String'];
+  name: Scalars['String'];
+  password: Scalars['String'];
 };
 
 export type Store = {
-  __typename?: "Store";
-  address: Scalars["String"];
-  code: Scalars["String"];
-  id: Scalars["ID"];
-  name: Scalars["String"];
-  ownerId: Scalars["Int"];
-  phone: Scalars["String"];
+  __typename?: 'Store';
+  address: Scalars['String'];
+  code: Scalars['String'];
+  id: Scalars['ID'];
+  name: Scalars['String'];
+  ownerId: Scalars['Int'];
+  phone: Scalars['String'];
   products: Array<Product>;
 };
 
 export type TokenOutput = {
-  __typename?: "TokenOutput";
-  accessToken: Scalars["String"];
-  refreshToken: Scalars["String"];
+  __typename?: 'TokenOutput';
+  accessToken: Scalars['String'];
+  refreshToken: Scalars['String'];
 };
 
 export type User = {
-  __typename?: "User";
-  email: Scalars["String"];
-  id: Scalars["ID"];
-  name: Scalars["String"];
+  __typename?: 'User';
+  email: Scalars['String'];
+  id: Scalars['ID'];
+  name: Scalars['String'];
 };
 
 export type RemoveProductInput = {
-  productIds: Array<Scalars["Int"]>;
+  productIds: Array<Scalars['Int']>;
 };
 
 export type RemoveProductOptionInput = {
-  OptionIds: Array<Scalars["Int"]>;
+  OptionIds: Array<Scalars['Int']>;
 };
 
 export type StoreQueryVariables = Exact<{
-  id: Scalars["Float"];
+  id: Scalars['Float'];
 }>;
 
-export type StoreQuery = {
-  __typename?: "Query";
-  store?: {
-    __typename?: "Store";
-    products: Array<{ __typename?: "Product"; name: string }>;
-  } | null;
-};
+
+export type StoreQuery = { __typename?: 'Query', store?: { __typename?: 'Store', products: Array<{ __typename?: 'Product', name: string }> } | null };
+
+export type AddStoreMutationVariables = Exact<{
+  name: Scalars['String'];
+  code: Scalars['String'];
+  address: Scalars['String'];
+  phone: Scalars['String'];
+}>;
+
+
+export type AddStoreMutation = { __typename?: 'Mutation', addStore: boolean };
 
 export type LoginMutationVariables = Exact<{
-  email: Scalars["String"];
-  password: Scalars["String"];
+  email: Scalars['String'];
+  password: Scalars['String'];
 }>;
 
-export type LoginMutation = {
-  __typename?: "Mutation";
-  login: {
-    __typename?: "TokenOutput";
-    accessToken: string;
-    refreshToken: string;
-  };
-};
 
-export type MeQueryVariables = Exact<{ [key: string]: never }>;
+export type LoginMutation = { __typename?: 'Mutation', login: { __typename?: 'TokenOutput', accessToken: string, refreshToken: string } };
 
-export type MeQuery = {
-  __typename?: "Query";
-  me: { __typename?: "User"; id: string; name: string; email: string };
-};
+export type MeQueryVariables = Exact<{ [key: string]: never; }>;
+
+
+export type MeQuery = { __typename?: 'Query', me: { __typename?: 'User', id: string, name: string, email: string } };
+
 
 export const StoreDocument = `
     query store($id: Float!) {
@@ -268,22 +263,38 @@ export const StoreDocument = `
   }
 }
     `;
-export const useStoreQuery = <TData = StoreQuery, TError = unknown>(
-  client: GraphQLClient,
-  variables: StoreQueryVariables,
-  options?: UseQueryOptions<StoreQuery, TError, TData>,
-  headers?: RequestInit["headers"],
-) =>
-  useQuery<StoreQuery, TError, TData>(
-    ["store", variables],
-    fetcher<StoreQuery, StoreQueryVariables>(
-      client,
-      StoreDocument,
-      variables,
-      headers,
-    ),
-    options,
-  );
+export const useStoreQuery = <
+      TData = StoreQuery,
+      TError = unknown
+    >(
+      client: GraphQLClient,
+      variables: StoreQueryVariables,
+      options?: UseQueryOptions<StoreQuery, TError, TData>,
+      headers?: RequestInit['headers']
+    ) =>
+    useQuery<StoreQuery, TError, TData>(
+      ['store', variables],
+      fetcher<StoreQuery, StoreQueryVariables>(client, StoreDocument, variables, headers),
+      options
+    );
+export const AddStoreDocument = `
+    mutation addStore($name: String!, $code: String!, $address: String!, $phone: String!) {
+  addStore(store: {name: $name, code: $code, address: $address, phone: $phone})
+}
+    `;
+export const useAddStoreMutation = <
+      TError = unknown,
+      TContext = unknown
+    >(
+      client: GraphQLClient,
+      options?: UseMutationOptions<AddStoreMutation, TError, AddStoreMutationVariables, TContext>,
+      headers?: RequestInit['headers']
+    ) =>
+    useMutation<AddStoreMutation, TError, AddStoreMutationVariables, TContext>(
+      ['addStore'],
+      (variables?: AddStoreMutationVariables) => fetcher<AddStoreMutation, AddStoreMutationVariables>(client, AddStoreDocument, variables, headers)(),
+      options
+    );
 export const LoginDocument = `
     mutation login($email: String!, $password: String!) {
   login(email: $email, password: $password) {
@@ -292,28 +303,19 @@ export const LoginDocument = `
   }
 }
     `;
-export const useLoginMutation = <TError = unknown, TContext = unknown>(
-  client: GraphQLClient,
-  options?: UseMutationOptions<
-    LoginMutation,
-    TError,
-    LoginMutationVariables,
-    TContext
-  >,
-  headers?: RequestInit["headers"],
-) =>
-  useMutation<LoginMutation, TError, LoginMutationVariables, TContext>(
-    ["login"],
-    (variables?: LoginMutationVariables) =>
-      fetcher<LoginMutation, LoginMutationVariables>(
-        client,
-        LoginDocument,
-        variables,
-        headers,
-      )(),
-    options,
-  );
-
+export const useLoginMutation = <
+      TError = unknown,
+      TContext = unknown
+    >(
+      client: GraphQLClient,
+      options?: UseMutationOptions<LoginMutation, TError, LoginMutationVariables, TContext>,
+      headers?: RequestInit['headers']
+    ) =>
+    useMutation<LoginMutation, TError, LoginMutationVariables, TContext>(
+      ['login'],
+      (variables?: LoginMutationVariables) => fetcher<LoginMutation, LoginMutationVariables>(client, LoginDocument, variables, headers)(),
+      options
+    );
 export const MeDocument = `
     query me {
   me {
@@ -323,15 +325,17 @@ export const MeDocument = `
   }
 }
     `;
-
-export const useMeQuery = <TData = MeQuery, TError = unknown>(
-  client: GraphQLClient,
-  variables?: MeQueryVariables,
-  options?: UseQueryOptions<MeQuery, TError, TData>,
-  headers?: RequestInit["headers"],
-) =>
-  useQuery<MeQuery, TError, TData>(
-    variables === undefined ? ["me"] : ["me", variables],
-    fetcher<MeQuery, MeQueryVariables>(client, MeDocument, variables, headers),
-    options,
-  );
+export const useMeQuery = <
+      TData = MeQuery,
+      TError = unknown
+    >(
+      client: GraphQLClient,
+      variables?: MeQueryVariables,
+      options?: UseQueryOptions<MeQuery, TError, TData>,
+      headers?: RequestInit['headers']
+    ) =>
+    useQuery<MeQuery, TError, TData>(
+      variables === undefined ? ['me'] : ['me', variables],
+      fetcher<MeQuery, MeQueryVariables>(client, MeDocument, variables, headers),
+      options
+    );

--- a/src/graphql/store.graphql
+++ b/src/graphql/store.graphql
@@ -1,0 +1,18 @@
+query store($id: Float!) {
+  store(id: $id) {
+    products {
+      name
+    }
+  }
+}
+
+mutation addStore(
+  $name: String!
+  $code: String!
+  $address: String!
+  $phone: String!
+) {
+  addStore(
+    store: { name: $name, code: $code, address: $address, phone: $phone }
+  )
+}

--- a/src/lib/interface.ts
+++ b/src/lib/interface.ts
@@ -1,0 +1,22 @@
+export interface ErrorState {
+  response: {
+    errors: [
+      {
+        message: string;
+        extensions: {
+          code: string;
+          exception: {
+            response: {
+              error: string;
+            };
+            status: number;
+            message: string;
+            name: string;
+          };
+        };
+      },
+    ];
+    data: null;
+    status: number;
+  };
+}


### PR DESCRIPTION
# 개요
Create Store 구현
# 작업 내용
    AdminCreateStore.tsx
    - 가게를 등록할 수 있다.
    - 가게 필드는 전부 필수 입력 사항.
    - 가게 등록에 성공하면 가게 목록 페이지로 이동.
    AdminStoreList.tsx
    - 가게등록 버튼을 누르면 가게 등록 페이지로 이동.
    Router.tsx
    -:id=> userId, storeId로 변경.
    graphql.ts
    -useAddStoreMutation을 새로 생성.
    store.graphql
    - store, addStore 쿼리, 뮤테이션 작성

# 스크린샷 
<img width="973" alt="스크린샷 2022-06-16 오후 9 41 09" src="https://user-images.githubusercontent.com/44064122/174288680-a3933eeb-aa52-48ce-8085-2faa5d4e3493.png">
<img width="963" alt="스크린샷 2022-06-16 오후 9 41 24" src="https://user-images.githubusercontent.com/44064122/174288931-c9ea75a1-098e-4564-b056-096a9b4f896f.png">
