### PR TITLE
feat:가게 리스트, 등록, 수정, 삭제 구현

### DIFF
--- a/src/Components/Form/InputDefault.tsx
+++ b/src/Components/Form/InputDefault.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import {
+  FieldError,
   FieldValues,
   RegisterOptions,
   useForm,
@@ -25,24 +26,30 @@ const InputDefault = ({
   error,
   ...props
 }: IInputProps) => {
-  return register ? (
-    fieldName ? (
+  if (!register) {
+    return (
       <>
-        <input
-          {...props}
-          {...register(`${fieldName}.${props.name}`, registerOptions)}
-        />
+        <input {...props} />
         {error && <Label className="error-label">{error}</Label>}
       </>
-    ) : (
+    );
+  }
+
+  if (!fieldName) {
+    return (
       <>
         <input {...props} {...register(`${props.name}`, registerOptions)} />
         {error && <Label className="error-label">{error}</Label>}
       </>
-    )
-  ) : (
+    );
+  }
+
+  return (
     <>
-      <input {...props} />
+      <input
+        {...props}
+        {...register(`${fieldName}.${props.name}`, registerOptions)}
+      />
       {error && <Label className="error-label">{error}</Label>}
     </>
   );

--- a/src/Components/Modals/Modal.tsx
+++ b/src/Components/Modals/Modal.tsx
@@ -41,7 +41,7 @@ const ModalContainer: React.FC<IModalProps> = styled.div<IModalProps>`
   }
 `;
 
-const ModalWrapper = styled.div`
+const TransparentBackground = styled.div`
   position: absolute;
   z-index: -1;
   top: 0;
@@ -60,7 +60,7 @@ const Modal = ({ strach, children }: IModalProps) => {
   return (
     <Wrapper>
       <ModalContainer strach={strach}>{children}</ModalContainer>
-      <ModalWrapper />
+      <TransparentBackground />
     </Wrapper>
   );
 };

--- a/src/GlobalStyle.tsx
+++ b/src/GlobalStyle.tsx
@@ -28,7 +28,7 @@ article, aside, details, figcaption, figure,
 footer, header, hgroup, menu, nav, section {
 	display: block;
 }
-body {
+html, body {
 	font-size:10px;
 	font-family: "Noto Sans KR", sans-serif;
 	line-height: 1;

--- a/src/Page/Admin/Login/AdminLoadingAndGetUser.tsx
+++ b/src/Page/Admin/Login/AdminLoadingAndGetUser.tsx
@@ -13,6 +13,7 @@ const AdminLoadingAndGetUser = () => {
   const navigate = useNavigate();
   const [isUser, setIsUser] = useRecoilState(userState);
   const { setUser } = useSetUserInfoToLocalStorage();
+
   const { isSuccess, isRefetching } = useMeQuery<MeQuery, Error>(
     graphqlReqeustClient(isUser.accessToken),
     undefined,

--- a/src/Page/Admin/Login/AdminLogin.tsx
+++ b/src/Page/Admin/Login/AdminLogin.tsx
@@ -1,12 +1,12 @@
 import React, { useState } from "react";
-import { Link, useNavigate } from "react-router-dom";
+import { Link } from "react-router-dom";
 import { useForm } from "react-hook-form";
 
 import styled from "styled-components";
 import InputDefault from "../../../Components/Form/InputDefault";
 import Label from "../../../Components/Form/LabelDefault";
 
-import { Headline2, SubTitle1, SubTitle2 } from "../../../mixin";
+import { SubTitle1, SubTitle2 } from "../../../mixin";
 import { useRecoilState } from "recoil";
 import { userState } from "../../../state/userState";
 import { useLoginMutation } from "../../../generated/graphql";
@@ -114,8 +114,6 @@ const AdminMain = () => {
         login: { accessToken, refreshToken },
       } = data;
 
-      localStorage.setItem("accessToken", accessToken);
-      localStorage.setItem("refreshToken", refreshToken);
       setIsUser((pre) => ({
         ...pre,
         isLogin: true,

--- a/src/Page/Admin/Modal/IsOpenModalChildren.tsx
+++ b/src/Page/Admin/Modal/IsOpenModalChildren.tsx
@@ -31,7 +31,7 @@ const StartConfirmButton = styled(ButtonDefaultStyle)`
 interface IIsOpenModalChildrenProps {
   setModal: React.Dispatch<React.SetStateAction<boolean>>;
   setConfirm: React.Dispatch<React.SetStateAction<boolean>>;
-  toggleState: boolean;
+  toggleState: boolean | undefined;
 }
 
 const IsOpenModalChildren = ({

--- a/src/Page/Admin/Store/AdminCreateStore.tsx
+++ b/src/Page/Admin/Store/AdminCreateStore.tsx
@@ -91,7 +91,7 @@ interface IStoreFormProps {
 }
 
 const AdminStore = () => {
-  const id = useParams();
+  const user = useRecoilValue(userState);
   const navigate = useNavigate();
   const [isLoading, setIsLoading] = useState(false);
   const [errorState, setErrorState] = useState<ErrorState>();
@@ -131,7 +131,7 @@ const AdminStore = () => {
     if (isSuccess && data.addStore) {
       time = setTimeout(() => {
         setIsLoading(false);
-        navigate(`/admin/${id}/store`);
+        navigate(`/admin/${user.id}/store/list`);
       }, 3000);
     }
     return () => time && clearTimeout(time);
@@ -142,7 +142,7 @@ const AdminStore = () => {
       {isLoading && (
         <Loading
           title="가게를 등록 하고있어요."
-          subTitle="첫 가게를 등록하신 것을 축하드립니다 🎉"
+          subTitle="가게를 등록하신 것을 축하드립니다! 🎉"
         />
       )}
       <Form onSubmit={onSubmit}>

--- a/src/Page/Admin/Store/AdminStoreList.tsx
+++ b/src/Page/Admin/Store/AdminStoreList.tsx
@@ -1,13 +1,23 @@
-import React, { useEffect, useMemo } from "react";
 import styled from "styled-components";
 import PageHeaderMessage from "../../../Components/PageHeader";
 import ButtonDefaultStyle from "../../../Components/Buttons/ButtonDefault";
 import { MdAddCircle } from "react-icons/md";
-import { Link } from "react-router-dom";
-import { useRecoilValue } from "recoil";
+import { Link, useNavigate } from "react-router-dom";
+import { useRecoilState, useRecoilValue } from "recoil";
 import { userState } from "../../../state/userState";
-
-interface IAdminStoreListProps {}
+import {
+  useRemoveStoreMutation,
+  useStoreQuery,
+  useStoresQuery,
+} from "../../../generated/graphql";
+import graphqlReqeustClient from "../../../lib/graphqlRequestClient";
+import { storeState, storeStateProps } from "../../../state/storeState";
+import { Headline2 } from "../../../mixin";
+import { useEffect, useState } from "react";
+import Modal from "../../../Components/Modals/Modal";
+import IsOpenModalChildren from "../Modal/IsOpenModalChildren";
+import { useQueryClient } from "react-query";
+import { MdDelete, MdCreate } from "react-icons/md";
 
 const Wrapper = styled.div``;
 const Header = styled.div`
@@ -20,26 +30,211 @@ const AddStoreButton = styled(ButtonDefaultStyle)`
   align-items: center;
   color: ${(props) => props.theme.color.fontColorBlack};
   background-color: unset;
+  a {
+    text-decoration: none;
+    color: ${(props) => props.theme.color.fontColorBlack};
+  }
   span {
     margin-left: 0.5rem;
   }
 `;
 
+const StoreList = styled.ul`
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  grid-gap: 1rem;
+  grid-template-rows: minmax(15rem, 15rem);
+`;
+
+const Item = styled.li`
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  height: inherit;
+  position: relative;
+  border: 1px solid ${(props) => props.theme.color.gray300};
+  border-radius: 1rem;
+  padding: 0.5rem 1rem;
+  a {
+    text-decoration: none;
+    color: ${(props) => props.theme.color.fontColorBlack};
+  }
+  h3 {
+    ${Headline2};
+    padding: 0;
+    margin: 0;
+  }
+  .button-container {
+    display: flex;
+    justify-content: space-between;
+  }
+  .various-button-box {
+    button {
+      cursor: pointer;
+      border: 0;
+      background-color: unset;
+      padding: 0;
+      font-size: 2rem;
+      color: ${(props) => props.theme.color.gray400};
+    }
+    .delete-button {
+      margin-left: 1.8rem;
+    }
+  }
+`;
+
+const ToggleButton: React.FC<
+  | IAdminMenuProps
+  | React.DetailedHTMLProps<
+      React.HTMLAttributes<HTMLDivElement>,
+      HTMLDivElement
+    >
+> = styled.div<IAdminMenuProps>`
+  position: relative;
+  z-index: 1;
+  width: 3rem;
+  height: 1rem;
+  cursor: pointer;
+  background-color: ${(props) =>
+    props.isActive ? props.theme.color.primary600 : props.theme.color.error500};
+  border: 0;
+  border-radius: 2rem;
+  padding: 0.5rem 0.3rem;
+  margin: 0.5rem;
+  box-shadow: inset 0.1rem 0.15rem 0.2rem
+    ${(props) =>
+      props.isActive
+        ? props.theme.color.primary800
+        : props.theme.color.error800};
+  &::before {
+    position: absolute;
+    top: 50%;
+    left: ${(props) => (props.isActive ? "unset" : "0.2rem")};
+    right: ${(props) => (props.isActive ? "0.2rem" : "unset")};
+    transform: translateY(-50%);
+    width: 1.7rem;
+    height: 1.7rem;
+    border-radius: 2rem;
+    background-color: ${(props) => props.theme.color.background100};
+    content: "";
+  }
+`;
+
+interface IAdminMenuProps {
+  isActive: boolean;
+}
+
+interface IAdminStoreListProps {}
+
 const AdminStoreList = () => {
+  const [toggleState, setToggleState] = useState(false);
+  const [isModal, setIsModal] = useState(false);
+  const [confirm, setConfirm] = useState(false);
+  const navigate = useNavigate();
   const user = useRecoilValue(userState);
+  const [store, setStore] = useRecoilState(storeState);
+  const queryClient = useQueryClient();
+  const storeQuery = useStoresQuery(
+    graphqlReqeustClient(user.accessToken),
+    undefined,
+    {
+      onSuccess: (data) => {
+        const stores = data.stores.map<storeStateProps>((value) => ({
+          id: value?.id,
+          name: value?.name,
+          code: value?.code,
+          address: value?.address,
+          phone: value?.phone,
+        }));
+
+        setStore(stores);
+      },
+    },
+  );
+  const { mutate } = useRemoveStoreMutation(
+    graphqlReqeustClient(user.accessToken),
+    {
+      onSuccess: () => {
+        queryClient.invalidateQueries("stores");
+      },
+    },
+  );
+  const toggleHandler = () => {
+    setIsModal(true);
+  };
+
+  const handleDeleteItem = (id: string | undefined) => {
+    mutate({ id: Number(id) });
+  };
+
+  useEffect(() => {
+    if (confirm) {
+      setToggleState((preValue) => !preValue);
+      setConfirm(false);
+    }
+  }, [confirm]);
 
   return (
     <Wrapper>
+      {isModal && (
+        <Modal>
+          <IsOpenModalChildren
+            toggleState={toggleState}
+            setModal={setIsModal}
+            setConfirm={setConfirm}
+          />
+        </Modal>
+      )}
       <Header>
         <PageHeaderMessage
           header="가게목록"
-          message="아직 등록된 가게가 없습니다."
+          message={
+            store.length !== 0
+              ? "가게를 선택하세요."
+              : "아직 등록된 가게가 없습니다."
+          }
         />
         <AddStoreButton>
           <MdAddCircle />
           <Link to={`/admin/${user.id}/store/create`}>가게등록</Link>
         </AddStoreButton>
       </Header>
+
+      <StoreList>
+        {store.map((item) => (
+          <Item>
+            <Link to={`/admin/${user.id}/store/${item.id}/main`}>
+              <h3>{item.name}</h3>
+            </Link>
+            <div className="button-container">
+              <div className="toggle-button-box">
+                <ToggleButton
+                  isActive={toggleState}
+                  onClick={toggleHandler}
+                ></ToggleButton>
+              </div>
+              <div className="various-button-box">
+                <button
+                  className="update-button"
+                  onClick={() =>
+                    navigate(`/admin/${user.id}/store/${item.id}/update`)
+                  }
+                >
+                  <MdCreate />
+                  <span>수정</span>
+                </button>
+                <button
+                  className="delete-button"
+                  onClick={() => handleDeleteItem(item?.id)}
+                >
+                  <MdDelete />
+                  <span>삭제</span>
+                </button>
+              </div>
+            </div>
+          </Item>
+        ))}
+      </StoreList>
     </Wrapper>
   );
 };

--- a/src/Page/Admin/Store/AdminUpdateStore.tsx
+++ b/src/Page/Admin/Store/AdminUpdateStore.tsx
@@ -1,9 +1,230 @@
-import React from "react";
+import React, { useEffect, useState } from "react";
+import { useForm } from "react-hook-form";
+import { useQueryClient } from "react-query";
+import { useNavigate, useParams } from "react-router-dom";
+import { useRecoilValue } from "recoil";
+import styled from "styled-components";
+import InputDefault from "../../../Components/Form/InputDefault";
+import LabelDefault from "../../../Components/Form/LabelDefault";
+import Loading from "../../../Components/Loading";
+import { useAddStoreMutation, useStoreQuery } from "../../../generated/graphql";
+import graphqlReqeustClient from "../../../lib/graphqlRequestClient";
+import { ErrorState } from "../../../lib/interface";
+import { SubTitle1, SubTitle2 } from "../../../mixin";
+import { userState } from "../../../state/userState";
+import { handleErrorMessage } from "../../../utils/helper/handleErrorMessage";
 
-interface IAdminUpdateStoreProps {}
+const Form = styled.form`
+  width: 100%;
+`;
+const InputContainer = styled.div`
+  display: grid;
+  border-bottom: 1px solid ${(props) => props.theme.color.gray300};
+  grid-template-columns: repeat(auto-fill, minmax(20%, auto));
+  label {
+    grid-column: 1 / 2;
+    ${SubTitle1};
+  }
+  input {
+    grid-column: 2 / 10;
+    ${SubTitle2};
+    border: unset;
+    outline: unset;
+  }
+  .error-label {
+    grid-column: 2 / 10;
+    ${SubTitle2};
+    color: ${(props) => props.theme.color.error500};
+  }
+`;
+
+const StatusBar = styled.div`
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  padding: 0 1rem;
+  height: 5rem;
+
+  .status-bar-item-container {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    height: 100%;
+    border-top: 1px solid ${(props) => props.theme.color.gray300};
+  }
+  .status-message-container {
+    h2 {
+      font-size: 2rem;
+      font-weight: bold;
+      color: ${(props) => props.theme.color.fontColorBlack};
+    }
+  }
+  .status-button-container {
+    button {
+      cursor: pointer;
+      padding: 0.5rem 1.8rem;
+      border: 0;
+      font-size: 2rem;
+      color: ${(props) => props.theme.color.fontColorWhite};
+      border-radius: 0.2rem;
+      line-height: 2.8rem;
+    }
+
+    .cancel-button {
+      background-color: ${(props) => props.theme.color.gray300};
+    }
+    .confirm-button {
+      margin-left: 0.5rem;
+      background-color: ${(props) => props.theme.color.primary700};
+    }
+  }
+`;
+
+interface IAdminStoreProps {}
+interface IStoreFormProps {
+  name: string;
+  code: string;
+  phone: string;
+  address: string;
+  addFail?: string;
+}
 
 const AdminUpdateStore = () => {
-  return <div>AdminUpdateStore</div>;
+  const user = useRecoilValue(userState);
+  const { storeId } = useParams();
+  const navigate = useNavigate();
+  const [isLoading, setIsLoading] = useState(false);
+  const [errorState, setErrorState] = useState<ErrorState>();
+  const { accessToken } = useRecoilValue(userState);
+  const queryClient = useQueryClient();
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+    setError,
+  } = useForm<IStoreFormProps>();
+
+  const { data: updateStore } = useStoreQuery(
+    graphqlReqeustClient(accessToken),
+    {
+      id: Number(storeId),
+    },
+  );
+
+  //TODO: update store mutation이 필요합니다.
+  // const { mutate, data, isSuccess } = useAddStoreMutation<Error>(
+  //   graphqlReqeustClient(accessToken),
+  //   {
+  //     onSuccess: () => {
+  //       queryClient.invalidateQueries("stores");
+  //     },
+  //     onError: (error) => {
+  //       handleErrorMessage(error, setErrorState);
+  //       if (errorState) {
+  //         const [message] = errorState?.response.errors;
+  //         const error = message.extensions.exception.response.error;
+  //         setError("addFail", { message: error });
+  //       }
+  //     },
+  //   },
+  // );
+
+  const onSubmit = handleSubmit((data) => {
+    // mutate({ ...data });
+    setIsLoading(true);
+  });
+
+  // useEffect(() => {
+  //   let time: NodeJS.Timeout;
+  //   if (isSuccess && data.addStore) {
+  //     time = setTimeout(() => {
+  //       setIsLoading(false);
+  //       navigate(`/admin/${user.id}/store/list`);
+  //     }, 3000);
+  //   }
+  //   return () => time && clearTimeout(time);
+  // }, [isSuccess, data]);
+
+  return (
+    <>
+      {isLoading && (
+        <Loading
+          title="가게 정보를 수정하고 있습니다."
+          subTitle="잠시만 기다려주세요."
+        />
+      )}
+      <Form onSubmit={onSubmit}>
+        <InputContainer>
+          <LabelDefault htmlFor="code">사업자번호</LabelDefault>
+          <InputDefault
+            id="code"
+            name="code"
+            placeholder="사업자 번호를 입력해주세요."
+            value={updateStore?.store?.code}
+            register={register}
+            registerOptions={{ required: "사업자 번호가 꼭 필요해요." }}
+            error={errors.code?.message}
+          />
+        </InputContainer>
+        <InputContainer>
+          <LabelDefault htmlFor="name">가게이름</LabelDefault>
+          <InputDefault
+            id="name"
+            name="name"
+            placeholder="가게 이름을 입력해주세요."
+            value={updateStore?.store?.name}
+            register={register}
+            registerOptions={{ required: "가게 이름이 꼭 있어야합니다." }}
+            error={errors.name?.message}
+          />
+        </InputContainer>
+        <InputContainer>
+          <LabelDefault htmlFor="address">주소</LabelDefault>
+          <InputDefault
+            id="address"
+            name="address"
+            placeholder="주소를 입력해주세요."
+            value={updateStore?.store?.address}
+            register={register}
+            registerOptions={{ required: "주소가 꼭 있어야합니다." }}
+            error={errors.address?.message}
+          />
+        </InputContainer>
+        <InputContainer>
+          <LabelDefault htmlFor="phone">전화번호</LabelDefault>
+          <InputDefault
+            id="phone"
+            name="phone"
+            placeholder="가게 대표 번호를 입력해주세요."
+            value={updateStore?.store?.phone}
+            register={register}
+            registerOptions={{ required: "대표 번호가 꼭 필요합니다." }}
+            error={errors.phone?.message}
+          />
+        </InputContainer>
+        <input style={{ visibility: "hidden" }} type="submit" />
+      </Form>
+      <LabelDefault className="error-label">
+        {errors.addFail?.message}
+      </LabelDefault>
+      <StatusBar>
+        <div className="status-bar-item-container">
+          <div className="status-message-container">
+            <h2>입력이 끝나면 수정하기 버튼을 눌러주세요.</h2>
+          </div>
+          <div className="status-button-container">
+            <button onClick={() => navigate(-1)} className="cancel-button">
+              돌아가기
+            </button>
+            <button onClick={onSubmit} className="confirm-button">
+              수정하기
+            </button>
+          </div>
+        </div>
+      </StatusBar>
+    </>
+  );
 };
 
 export default AdminUpdateStore;

--- a/src/Page/Admin/Store/AdminUpdateStore.tsx
+++ b/src/Page/Admin/Store/AdminUpdateStore.tsx
@@ -7,27 +7,37 @@ import styled from "styled-components";
 import InputDefault from "../../../Components/Form/InputDefault";
 import LabelDefault from "../../../Components/Form/LabelDefault";
 import Loading from "../../../Components/Loading";
-import { useAddStoreMutation, useStoreQuery } from "../../../generated/graphql";
+import {
+  useAddStoreMutation,
+  useStoreQuery,
+  useUpdateStoreMutation,
+} from "../../../generated/graphql";
 import graphqlReqeustClient from "../../../lib/graphqlRequestClient";
 import { ErrorState } from "../../../lib/interface";
 import { SubTitle1, SubTitle2 } from "../../../mixin";
+import { storeStateProps } from "../../../state/storeState";
 import { userState } from "../../../state/userState";
 import { handleErrorMessage } from "../../../utils/helper/handleErrorMessage";
 
 const Form = styled.form`
   width: 100%;
 `;
-const InputContainer = styled.div`
+const InputContainer = styled.div<{ disabled?: boolean }>`
   display: grid;
   border-bottom: 1px solid ${(props) => props.theme.color.gray300};
   grid-template-columns: repeat(auto-fill, minmax(20%, auto));
+
   label {
     grid-column: 1 / 2;
     ${SubTitle1};
+    color: ${({ disabled, theme }) =>
+      disabled ? theme.color.gray300 : theme.color.fontColorBlack};
   }
   input {
     grid-column: 2 / 10;
     ${SubTitle2};
+    color: ${({ disabled, theme }) =>
+      disabled ? theme.color.gray300 : theme.color.fontColorBlack};
     border: unset;
     outline: unset;
   }
@@ -82,9 +92,10 @@ const StatusBar = styled.div`
 `;
 
 interface IAdminStoreProps {}
+
 interface IStoreFormProps {
   name: string;
-  code: string;
+  code?: string;
   phone: string;
   address: string;
   addFail?: string;
@@ -92,12 +103,45 @@ interface IStoreFormProps {
 
 const AdminUpdateStore = () => {
   const user = useRecoilValue(userState);
+
+  const [store, setStore] = useState<{
+    name: string;
+    phone: string;
+    code: string;
+    address: string;
+  }>({
+    name: "",
+    phone: "",
+    code: "",
+    address: "",
+  });
+
   const { storeId } = useParams();
   const navigate = useNavigate();
   const [isLoading, setIsLoading] = useState(false);
   const [errorState, setErrorState] = useState<ErrorState>();
   const { accessToken } = useRecoilValue(userState);
   const queryClient = useQueryClient();
+
+  const {
+    data: updateStore,
+
+    isFetched,
+  } = useStoreQuery(
+    graphqlReqeustClient(accessToken),
+    {
+      id: Number(storeId),
+    },
+    {
+      onSuccess: (data) => {
+        if (data.store) {
+          const { name, code, address, phone } = data.store;
+          setStore({ name, code, address, phone });
+        }
+      },
+    },
+  );
+
   const {
     register,
     handleSubmit,
@@ -105,46 +149,45 @@ const AdminUpdateStore = () => {
     setError,
   } = useForm<IStoreFormProps>();
 
-  const { data: updateStore } = useStoreQuery(
+  const { mutate, data, isSuccess } = useUpdateStoreMutation<Error>(
     graphqlReqeustClient(accessToken),
     {
-      id: Number(storeId),
+      onSuccess: () => {
+        queryClient.invalidateQueries("stores");
+      },
+      onError: (error) => {
+        handleErrorMessage(error, setErrorState);
+        if (errorState) {
+          const [message] = errorState?.response.errors;
+          const error = message.extensions.exception.response.error;
+          setError("addFail", { message: error });
+          setIsLoading(false);
+        }
+      },
     },
   );
 
-  //TODO: update store mutation이 필요합니다.
-  // const { mutate, data, isSuccess } = useAddStoreMutation<Error>(
-  //   graphqlReqeustClient(accessToken),
-  //   {
-  //     onSuccess: () => {
-  //       queryClient.invalidateQueries("stores");
-  //     },
-  //     onError: (error) => {
-  //       handleErrorMessage(error, setErrorState);
-  //       if (errorState) {
-  //         const [message] = errorState?.response.errors;
-  //         const error = message.extensions.exception.response.error;
-  //         setError("addFail", { message: error });
-  //       }
-  //     },
-  //   },
-  // );
-
   const onSubmit = handleSubmit((data) => {
-    // mutate({ ...data });
+    console.log(data);
+    mutate({
+      id: Number(updateStore?.store?.id),
+      name: data.name,
+      address: data.address,
+      phone: data.phone,
+    });
     setIsLoading(true);
   });
 
-  // useEffect(() => {
-  //   let time: NodeJS.Timeout;
-  //   if (isSuccess && data.addStore) {
-  //     time = setTimeout(() => {
-  //       setIsLoading(false);
-  //       navigate(`/admin/${user.id}/store/list`);
-  //     }, 3000);
-  //   }
-  //   return () => time && clearTimeout(time);
-  // }, [isSuccess, data]);
+  useEffect(() => {
+    let time: NodeJS.Timeout;
+    if (isSuccess && data.updateStore) {
+      time = setTimeout(() => {
+        setIsLoading(false);
+        navigate(`/admin/${user.id}/store/list`);
+      }, 3000);
+    }
+    return () => time && clearTimeout(time);
+  }, [isSuccess, data]);
 
   return (
     <>
@@ -154,75 +197,85 @@ const AdminUpdateStore = () => {
           subTitle="잠시만 기다려주세요."
         />
       )}
-      <Form onSubmit={onSubmit}>
-        <InputContainer>
-          <LabelDefault htmlFor="code">사업자번호</LabelDefault>
-          <InputDefault
-            id="code"
-            name="code"
-            placeholder="사업자 번호를 입력해주세요."
-            value={updateStore?.store?.code}
-            register={register}
-            registerOptions={{ required: "사업자 번호가 꼭 필요해요." }}
-            error={errors.code?.message}
-          />
-        </InputContainer>
-        <InputContainer>
-          <LabelDefault htmlFor="name">가게이름</LabelDefault>
-          <InputDefault
-            id="name"
-            name="name"
-            placeholder="가게 이름을 입력해주세요."
-            value={updateStore?.store?.name}
-            register={register}
-            registerOptions={{ required: "가게 이름이 꼭 있어야합니다." }}
-            error={errors.name?.message}
-          />
-        </InputContainer>
-        <InputContainer>
-          <LabelDefault htmlFor="address">주소</LabelDefault>
-          <InputDefault
-            id="address"
-            name="address"
-            placeholder="주소를 입력해주세요."
-            value={updateStore?.store?.address}
-            register={register}
-            registerOptions={{ required: "주소가 꼭 있어야합니다." }}
-            error={errors.address?.message}
-          />
-        </InputContainer>
-        <InputContainer>
-          <LabelDefault htmlFor="phone">전화번호</LabelDefault>
-          <InputDefault
-            id="phone"
-            name="phone"
-            placeholder="가게 대표 번호를 입력해주세요."
-            value={updateStore?.store?.phone}
-            register={register}
-            registerOptions={{ required: "대표 번호가 꼭 필요합니다." }}
-            error={errors.phone?.message}
-          />
-        </InputContainer>
-        <input style={{ visibility: "hidden" }} type="submit" />
-      </Form>
-      <LabelDefault className="error-label">
-        {errors.addFail?.message}
-      </LabelDefault>
-      <StatusBar>
-        <div className="status-bar-item-container">
-          <div className="status-message-container">
-            <h2>입력이 끝나면 수정하기 버튼을 눌러주세요.</h2>
-          </div>
-          <div className="status-button-container">
-            <button onClick={() => navigate(-1)} className="cancel-button">
-              돌아가기
-            </button>
-            <button onClick={onSubmit} className="confirm-button">
-              수정하기
-            </button>
-          </div>
-        </div>
-      </StatusBar>
+
+      {store.name && (
+        <>
+          <Form onSubmit={onSubmit}>
+            <InputContainer disabled>
+              <LabelDefault htmlFor="code">사업자번호</LabelDefault>
+              <InputDefault
+                id="code"
+                name="code"
+                placeholder="사업자 번호를 입력해주세요."
+                value={store.code}
+                register={register}
+                error={errors.code?.message}
+              />
+            </InputContainer>
+            <InputContainer>
+              <LabelDefault htmlFor="name">가게이름</LabelDefault>
+              <InputDefault
+                id="name"
+                name="name"
+                placeholder="가게 이름을 입력해주세요."
+                register={register}
+                defaultValue={store.name}
+                registerOptions={{
+                  required: "가게 이름이 꼭 있어야합니다.",
+                }}
+                error={errors.name?.message}
+              />
+            </InputContainer>
+            <InputContainer>
+              <LabelDefault htmlFor="address">주소</LabelDefault>
+              <InputDefault
+                id="address"
+                name="address"
+                placeholder="주소를 입력해주세요."
+                defaultValue={store.address}
+                register={register}
+                registerOptions={{
+                  required: "주소가 꼭 있어야합니다.",
+                }}
+                error={errors.address?.message}
+              />
+            </InputContainer>
+            <InputContainer>
+              <LabelDefault htmlFor="phone">전화번호</LabelDefault>
+              <InputDefault
+                id="phone"
+                name="phone"
+                placeholder="가게 대표 번호를 입력해주세요."
+                defaultValue={store.phone}
+                register={register}
+                registerOptions={{
+                  required: "대표 번호가 꼭 필요합니다.",
+                }}
+                error={errors.phone?.message}
+              />
+            </InputContainer>
+            <input style={{ visibility: "hidden" }} type="submit" />
+          </Form>
+          <LabelDefault className="error-label">
+            {errors.addFail?.message}
+          </LabelDefault>
+          <StatusBar>
+            <div className="status-bar-item-container">
+              <div className="status-message-container">
+                <h2>입력이 끝나면 수정하기 버튼을 눌러주세요.</h2>
+              </div>
+              <div className="status-button-container">
+                <button onClick={() => navigate(-1)} className="cancel-button">
+                  돌아가기
+                </button>
+                <button onClick={onSubmit} className="confirm-button">
+                  수정하기
+                </button>
+              </div>
+            </div>
+          </StatusBar>
+        </>
+      )}
     </>
   );
 };

--- a/src/Routers/Routers.tsx
+++ b/src/Routers/Routers.tsx
@@ -35,8 +35,8 @@ const Router = () => {
                 <Route path="" element={<Navigate to="list" />} />
                 <Route path="list" element={<AdminStoreList />} />
                 <Route path="create" element={<AdminCreateStore />} />
-                <Route path="update" element={<AdminUpdateStore />} />
                 <Route path=":storeId">
+                  <Route path="update" element={<AdminUpdateStore />} />
                   <Route path="main" element={<AdminMain />} />
                   <Route
                     path="manage-product"
@@ -57,15 +57,19 @@ const Router = () => {
             <Route path="menu" element={<ClientMenu />} />
             <Route path="select-list" element={<ClientSelectList />} />
           </Route>
+          <Route path="/logout" element={<Logout />} />
         </>
       )}
-      <Route path="/" element={<LandingLayout />}>
-        <Route path="/" element={<LandingMain />} />
-        <Route path="agreement" element={<Agreement />} />
-        <Route path="signup" element={<SignUp />} />
-        <Route path="login" element={<Login />} />
-        <Route path="logout" element={<Logout />} />
-      </Route>
+      {!isLogin && (
+        <>
+          <Route path="/" element={<ClientLayout />}>
+            <Route path="/" element={<LandingMain />} />
+            <Route path="agreement" element={<Agreement />} />
+            <Route path="signup" element={<SignUp />} />
+            <Route path="login" element={<Login />} />
+          </Route>
+        </>
+      )}
       <Route path="*" element={<PageNotFound />} />
     </Routes>
   );

--- a/src/Routers/Routers.tsx
+++ b/src/Routers/Routers.tsx
@@ -60,16 +60,14 @@ const Router = () => {
           <Route path="/logout" element={<Logout />} />
         </>
       )}
-      {!isLogin && (
-        <>
-          <Route path="/" element={<ClientLayout />}>
-            <Route path="/" element={<LandingMain />} />
-            <Route path="agreement" element={<Agreement />} />
-            <Route path="signup" element={<SignUp />} />
-            <Route path="login" element={<Login />} />
-          </Route>
-        </>
-      )}
+      {/* TODO: private router로 변경하면 login이 동작하지 않습니다. 왜냐하면
+      isLogin이 true이기 때문입니다. login이 전부 끝난 다음에 접근하지 못하도록 변경해야합니다.*/}
+      <Route path="/" element={<ClientLayout />}>
+        <Route path="/" element={<LandingMain />} />
+        <Route path="agreement" element={<Agreement />} />
+        <Route path="signup" element={<SignUp />} />
+        <Route path="login" element={<Login />} />
+      </Route>
       <Route path="*" element={<PageNotFound />} />
     </Routes>
   );

--- a/src/generated/graphql.ts
+++ b/src/generated/graphql.ts
@@ -228,7 +228,12 @@ export type StoreQueryVariables = Exact<{
 }>;
 
 
-export type StoreQuery = { __typename?: 'Query', store?: { __typename?: 'Store', products: Array<{ __typename?: 'Product', name: string }> } | null };
+export type StoreQuery = { __typename?: 'Query', store?: { __typename?: 'Store', id: string, name: string, code: string, phone: string, address: string } | null };
+
+export type StoresQueryVariables = Exact<{ [key: string]: never; }>;
+
+
+export type StoresQuery = { __typename?: 'Query', stores: Array<{ __typename?: 'Store', id: string, name: string, code: string, phone: string, address: string } | null> };
 
 export type AddStoreMutationVariables = Exact<{
   name: Scalars['String'];
@@ -239,6 +244,13 @@ export type AddStoreMutationVariables = Exact<{
 
 
 export type AddStoreMutation = { __typename?: 'Mutation', addStore: boolean };
+
+export type RemoveStoreMutationVariables = Exact<{
+  id: Scalars['Float'];
+}>;
+
+
+export type RemoveStoreMutation = { __typename?: 'Mutation', removeStore: boolean };
 
 export type LoginMutationVariables = Exact<{
   email: Scalars['String'];
@@ -257,9 +269,11 @@ export type MeQuery = { __typename?: 'Query', me: { __typename?: 'User', id: str
 export const StoreDocument = `
     query store($id: Float!) {
   store(id: $id) {
-    products {
-      name
-    }
+    id
+    name
+    code
+    phone
+    address
   }
 }
     `;
@@ -275,6 +289,31 @@ export const useStoreQuery = <
     useQuery<StoreQuery, TError, TData>(
       ['store', variables],
       fetcher<StoreQuery, StoreQueryVariables>(client, StoreDocument, variables, headers),
+      options
+    );
+export const StoresDocument = `
+    query stores {
+  stores {
+    id
+    name
+    code
+    phone
+    address
+  }
+}
+    `;
+export const useStoresQuery = <
+      TData = StoresQuery,
+      TError = unknown
+    >(
+      client: GraphQLClient,
+      variables?: StoresQueryVariables,
+      options?: UseQueryOptions<StoresQuery, TError, TData>,
+      headers?: RequestInit['headers']
+    ) =>
+    useQuery<StoresQuery, TError, TData>(
+      variables === undefined ? ['stores'] : ['stores', variables],
+      fetcher<StoresQuery, StoresQueryVariables>(client, StoresDocument, variables, headers),
       options
     );
 export const AddStoreDocument = `
@@ -293,6 +332,24 @@ export const useAddStoreMutation = <
     useMutation<AddStoreMutation, TError, AddStoreMutationVariables, TContext>(
       ['addStore'],
       (variables?: AddStoreMutationVariables) => fetcher<AddStoreMutation, AddStoreMutationVariables>(client, AddStoreDocument, variables, headers)(),
+      options
+    );
+export const RemoveStoreDocument = `
+    mutation removeStore($id: Float!) {
+  removeStore(id: $id)
+}
+    `;
+export const useRemoveStoreMutation = <
+      TError = unknown,
+      TContext = unknown
+    >(
+      client: GraphQLClient,
+      options?: UseMutationOptions<RemoveStoreMutation, TError, RemoveStoreMutationVariables, TContext>,
+      headers?: RequestInit['headers']
+    ) =>
+    useMutation<RemoveStoreMutation, TError, RemoveStoreMutationVariables, TContext>(
+      ['removeStore'],
+      (variables?: RemoveStoreMutationVariables) => fetcher<RemoveStoreMutation, RemoveStoreMutationVariables>(client, RemoveStoreDocument, variables, headers)(),
       options
     );
 export const LoginDocument = `

--- a/src/graphql/store.graphql
+++ b/src/graphql/store.graphql
@@ -1,8 +1,20 @@
 query store($id: Float!) {
   store(id: $id) {
-    products {
-      name
-    }
+    id
+    name
+    code
+    phone
+    address
+  }
+}
+
+query stores {
+  stores {
+    id
+    name
+    code
+    phone
+    address
   }
 }
 
@@ -15,4 +27,8 @@ mutation addStore(
   addStore(
     store: { name: $name, code: $code, address: $address, phone: $phone }
   )
+}
+
+mutation removeStore($id: Float!) {
+  removeStore(id: $id)
 }

--- a/src/graphql/store.graphql
+++ b/src/graphql/store.graphql
@@ -18,6 +18,21 @@ query stores {
   }
 }
 
+query myStores {
+  myStores {
+    id
+    name
+    code
+    address
+    phone
+    isAvailable
+  }
+}
+
+query storeIsAvailable($id: Float!) {
+  storeIsAvailable(id: $id)
+}
+
 mutation addStore(
   $name: String!
   $code: String!
@@ -31,4 +46,13 @@ mutation addStore(
 
 mutation removeStore($id: Float!) {
   removeStore(id: $id)
+}
+
+mutation updateStore(
+  $id: Float!
+  $name: String!
+  $address: String!
+  $phone: String!
+) {
+  updateStore(id: $id, store: { name: $name, address: $address, phone: $phone })
 }

--- a/src/state/storeState.ts
+++ b/src/state/storeState.ts
@@ -1,22 +1,24 @@
 import { atom } from "recoil";
 
 export interface storeStateProps {
-  id: string | undefined;
+  id?: string | undefined;
   name: string | undefined;
   code: string | undefined;
   address: string | undefined;
   phone: string | undefined;
+  isAvailable?: boolean | undefined;
 }
+
+const initialValue = {
+  id: "",
+  name: "",
+  code: "",
+  address: "",
+  phone: "",
+  isAvailable: false,
+};
 
 export const storeState = atom<storeStateProps[]>({
   key: "stores",
-  default: [
-    {
-      id: "",
-      name: "",
-      code: "",
-      address: "",
-      phone: "",
-    },
-  ],
+  default: [initialValue],
 });

--- a/src/state/storeState.ts
+++ b/src/state/storeState.ts
@@ -1,0 +1,22 @@
+import { atom } from "recoil";
+
+export interface storeStateProps {
+  id: string | undefined;
+  name: string | undefined;
+  code: string | undefined;
+  address: string | undefined;
+  phone: string | undefined;
+}
+
+export const storeState = atom<storeStateProps[]>({
+  key: "stores",
+  default: [
+    {
+      id: "",
+      name: "",
+      code: "",
+      address: "",
+      phone: "",
+    },
+  ],
+});

--- a/src/utils/customHooks/useModalHook.tsx
+++ b/src/utils/customHooks/useModalHook.tsx
@@ -1,0 +1,13 @@
+import React, { useState } from "react";
+
+interface IuseModalHookProps {}
+
+const useModalHook = () => {
+  const [isModal, setIsModal] = useState(false);
+  const [confirm, setConfirm] = useState(false);
+  const [id, setId] = useState<string | null>(null);
+
+  return { id, setId, isModal, setIsModal, confirm, setConfirm } as const;
+};
+
+export default useModalHook;


### PR DESCRIPTION
# 개요
가게 리스트, 등록, 수정, 삭제 구현

# 작업 내용

1. Components
- InputDefault.tsx
      - 기존에 삼항 연산자 로직이 복잡하여 if문으로 다시 선언.  
- Modal.tsx
      - styled 컴포넌트 이름 변경 : ModalWrapper=>TransparentBackground
2. Page
- AdminCreateStore 
     - 가게 등록 쿼리 추가. 새로운 가게를 등록할 수 있습니다.
- AdminStoreList : 가게 리스트 쿼리, 삭제, 수정 버튼 추가 및 스타일링
    - 삭제 버튼을 눌렀을 때 모달창으로 사용자의 의사를 한번 더 확인합니다.
    - 가게 오플 토글 버튼을 눌렀을 때, 사용자의 의사를 한번 더 확인합니다. 아직 isAvailable을 mutation하는 로직을 붙이지 않았습니다.
    - 로그인한 유저의 가게를 불러옵니다.
- AdminUpdateStore : 가게 목록 쿼리 추가.
    - 가게 이름, 주소, 전화번호를 업데이트 할 수 있습니다.
    - react query의 isSuccess가 true인데도 input에서 defaultValue를 빈값으로 인식하기 때문에 state값이 있는지 체크 한 후에 form을 그리도록 하였습니다.
3. graphql
- store.graphql
     - store, stores, removeStore, addStore, mystore, removeStore, updateStore를 추가하였습니다.
4. Utile - custom hook
- useModalHook.tsx
     - 모달 상태를 관리하기 위해 만들었습니다.
     - {id, isModal, isConfirm, setId, setIsModal, setIsConfirm}을 반환합니다.
5. Routers
  - isLogin값이 true일 때 private 라우터가 동작은 하지만 로그인이 전부 완료 되기 전에 true가 되기 때문에 로그인이 되지 않습니다. 임시로 isLogin을 삭제하였습니다.
6. State
- storeState
    - 정보를 서버로 받아 저장하는 atom
    - isAvailable을 추가하였습니다. true일 때만 가게 주문을 받을 수 있습니다.
7. Style
- GlobalStyle : noto sans적용을 html에 하여 웹 폰트 적용

# 스크린샷 
<img width="1459" alt="스크린샷 2022-06-20 오후 5 40 10" src="https://user-images.githubusercontent.com/44064122/174561577-28970ad9-229e-47db-9ee4-cb02884b3f8f.png">
<img width="1282" alt="스크린샷 2022-06-21 오전 10 47 38" src="https://user-images.githubusercontent.com/44064122/174699480-29c1fc61-6587-47d2-a7be-3143ee16db61.png">
<img width="1282" alt="스크린샷 2022-06-21 오전 10 47 41" src="https://user-images.githubusercontent.com/44064122/174699504-734d2d44-0f8b-49ff-8bd8-b194fae3189d.png">
<img width="1282" alt="스크린샷 2022-06-21 오전 10 47 46" src="https://user-images.githubusercontent.com/44064122/174699516-9413e6d1-0e0e-4ecd-b021-dd377cf2ea95.png">
<img width="1282" alt="스크린샷 2022-06-21 오전 10 47 51" src="https://user-images.githubusercontent.com/44064122/174699521-5893af13-31f8-4a6e-aa0f-fd82b137cddf.png">
