### PR TITLE
feat: 회원가입, 회원가입/가게 등록 구현

### DIFF
--- a/src/generated/graphql.ts
+++ b/src/generated/graphql.ts
@@ -253,6 +253,13 @@ export type MeQueryVariables = Exact<{ [key: string]: never; }>;
 
 export type MeQuery = { __typename?: 'Query', me: { __typename?: 'User', id: string, name: string, email: string } };
 
+export type SignupMutationVariables = Exact<{
+  user: SignupInput;
+}>;
+
+
+export type SignupMutation = { __typename?: 'Mutation', signup: { __typename?: 'TokenOutput', accessToken: string, refreshToken: string } };
+
 
 export const StoreDocument = `
     query store($id: Float!) {
@@ -337,5 +344,26 @@ export const useMeQuery = <
     useQuery<MeQuery, TError, TData>(
       variables === undefined ? ['me'] : ['me', variables],
       fetcher<MeQuery, MeQueryVariables>(client, MeDocument, variables, headers),
+      options
+    );
+export const SignupDocument = `
+    mutation signup($user: SignupInput!) {
+  signup(user: $user) {
+    accessToken
+    refreshToken
+  }
+}
+    `;
+export const useSignupMutation = <
+      TError = unknown,
+      TContext = unknown
+    >(
+      client: GraphQLClient,
+      options?: UseMutationOptions<SignupMutation, TError, SignupMutationVariables, TContext>,
+      headers?: RequestInit['headers']
+    ) =>
+    useMutation<SignupMutation, TError, SignupMutationVariables, TContext>(
+      ['signup'],
+      (variables?: SignupMutationVariables) => fetcher<SignupMutation, SignupMutationVariables>(client, SignupDocument, variables, headers)(),
       options
     );

--- a/src/graphql/user.graphql
+++ b/src/graphql/user.graphql
@@ -12,3 +12,10 @@ query me {
     email
   }
 }
+
+mutation signup($user: SignupInput!) {
+  signup(user: $user) {
+    accessToken
+    refreshToken
+  }
+}


### PR DESCRIPTION
# 개요
회원가입, 회원가입/가게 동시 등록

# 작업 내용
1. 회원 정보만 등록, 회원 정보와 가게 등록을 동시에 할 경우 각각 기능 구현

# 스크린샷 
필요하다면 첨부해주세요.

pull requests 내용을 작성하실때 'resolve: #[이슈넘버]'를 넣어주시면 merge될 때, 깃허브에서 자동으로 이슈를 close해줍니다.
