### PR TITLE
주문 데이터 쿼리 변경, 상품 옵션 수정,삭제,추가, 상품 세부 페이지 구현

### DIFF
--- a/src/Page/Admin/Product/AdminManageProductAddItem.tsx
+++ b/src/Page/Admin/Product/AdminManageProductAddItem.tsx
@@ -7,11 +7,11 @@ import InputDefault from "../../../Components/Form/InputDefault";
 import Label from "../../../Components/Form/LabelDefault";
 import Textarea from "../../../Components/Form/TextareaDefault";
 import ButtonDefaultStyle from "../../../Components/Buttons/ButtonDefault";
-import { IoIosAddCircle } from "react-icons/io";
+import { IoIosAddCircle, IoIosRemove, IoIosRemoveCircle } from "react-icons/io";
 import Modal from "../../../Components/Modals/Modal";
 import {
   useAddProductOptionsMutation,
-  useAddProductsMutation,
+  useAddProductsMutation
 } from "../../../generated/graphql";
 import graphqlReqeustClient from "../../../lib/graphqlRequestClient";
 import { useRecoilValue } from "recoil";
@@ -27,7 +27,7 @@ const Container = styled.div`
     fieldset {
       padding: 0.8rem;
       margin-bottom: 1rem;
-      div {
+      .product-input-container {
         display: grid;
         grid-template-columns: 20% 80%;
         padding: 1rem 0;
@@ -37,6 +37,8 @@ const Container = styled.div`
         label {
           font-size: 2rem;
           align-self: center;
+          font-weight: 700;
+          align-self: flex-start;
         }
         input {
           font-size: 2rem;
@@ -58,6 +60,20 @@ const Container = styled.div`
           outline: none;
           &::placeholder {
             font-size: 2rem;
+          }
+        }
+      }
+    }
+  }
+  ${({ theme }) => theme.device.mobile} {
+    form {
+      fieldset {
+        .product-input-container {
+          label {
+            font-size: 1.6rem;
+          }
+          input {
+            font-size: 1.6rem;
           }
         }
       }
@@ -132,6 +148,88 @@ const ModalChildren = styled.div`
   flex-direction: column;
 `;
 
+const OptionsField = styled.div`
+  .option-input-container,
+  .add-option-button-container {
+    display: grid;
+    grid-template-columns: 20% 80%;
+    padding: 1rem 0;
+    button {
+      cursor: pointer;
+      text-align: left;
+      padding: 0;
+      margin: 0;
+      &:hover {
+        color: ${(props) => props.theme.color.primary300};
+      }
+    }
+    &:not(:first-child) {
+      border-bottom: 1px solid ${(props) => props.theme.color.gray300};
+    }
+    label {
+      font-size: 2rem;
+      align-self: center;
+      font-weight: 700;
+    }
+    input {
+      font-size: 2rem;
+      border: 0;
+      align-self: center;
+      outline: none;
+    }
+
+    .option-label-button-container {
+      display: flex;
+      align-items: center;
+      justify-content: space-around;
+      button {
+        cursor: pointer;
+        font-size: 2rem;
+        text-align: left;
+        border: 0;
+        background-color: unset;
+        padding: 0;
+        margin: 0;
+        color: ${(props) => props.theme.color.error500};
+        &:hover {
+          color: ${(props) => props.theme.color.error900};
+        }
+        span {
+          position: absolute;
+          margin: -1px;
+          top: 0;
+          left: 0;
+          visibility: hidden;
+        }
+      }
+    }
+  }
+  .add-button {
+    cursor: pointer;
+    border: unset;
+    background-color: unset;
+    font-size: 2rem;
+    color: ${(props) => props.theme.color.primary700};
+    span {
+      visibility: hidden;
+    }
+  }
+  ${({ theme }) => theme.device.mobile} {
+    .option-input-container,
+    .add-option-button-container {
+      label {
+        font-size: 1.6rem;
+      }
+      input {
+        font-size: 1.6rem;
+      }
+    }
+    .option-input-container {
+      grid-template-columns: 30% 70%;
+    }
+  }
+`;
+
 const ModalButtonContainer = styled.div`
   display: flex;
   align-self: flex-end;
@@ -182,8 +280,8 @@ const AdminManageProductAddItem = () => {
       imageUrl: "",
       name: "",
       price: 0,
-      description: "",
-    },
+      description: ""
+    }
   ]);
 
   const [options, setOptions] = useState("");
@@ -192,7 +290,7 @@ const AdminManageProductAddItem = () => {
   >(graphqlReqeustClient(accessToken));
 
   const { mutate: addProductOptionMutate } = useAddProductOptionsMutation(
-    graphqlReqeustClient(accessToken),
+    graphqlReqeustClient(accessToken)
   );
 
   const {
@@ -201,7 +299,7 @@ const AdminManageProductAddItem = () => {
     control,
     formState: { errors },
     setError,
-    setValue,
+    setValue
   } = useForm<{ product: ProductDefaultValue[] }>({
     defaultValues: {
       product: [
@@ -209,15 +307,37 @@ const AdminManageProductAddItem = () => {
           imageUrl: "",
           name: "",
           price: 0,
-          description: "",
-        },
-      ],
-    },
+          description: ""
+        }
+      ]
+    }
+  });
+
+  const {
+    register: optionRegister,
+    handleSubmit: optionHandleSubmit,
+    control: optionControl,
+    formState: { errors: optionErrors },
+    setError: optionSetError,
+    getValues: optionValue
+  } = useForm<{ options: { name: string }[] }>({
+    defaultValues: {
+      options: [{ name: "기본" }]
+    }
+  });
+
+  const {
+    fields: optionsFields,
+    append: optionsAppend,
+    remove: optionsRemove
+  } = useFieldArray({
+    control: optionControl,
+    name: "options"
   });
 
   const { fields, append, remove } = useFieldArray({
     control,
-    name: "product",
+    name: "product"
   });
 
   const handleModal = () => {
@@ -225,6 +345,18 @@ const AdminManageProductAddItem = () => {
   };
 
   const onSubmit = handleSubmit((data) => {
+    const options = optionValue("options");
+
+    if (options.length === 0) {
+      optionSetError("options", {
+        message: "반드시 기본 옵션을 들어가야합니다."
+      });
+      return;
+    }
+    if (options.length !== 0 && optionErrors.options?.message) {
+      optionSetError("options", { message: "" });
+    }
+
     handleModal();
     setFormData(
       data.product.map((item) => ({
@@ -232,8 +364,8 @@ const AdminManageProductAddItem = () => {
         storeId: Number(storeId),
         name: item.name,
         price: Number(item.price),
-        description: item.description,
-      })),
+        description: item.description
+      }))
     );
   });
 
@@ -247,31 +379,24 @@ const AdminManageProductAddItem = () => {
       { products: formData },
       {
         onSuccess: (data) => {
-          if (!options) {
-            queryClient.invalidateQueries("getProducts");
-            navigate(
-              `/admin/${userId}/store/${storeId}/product/manage-product`,
-            );
-            return;
-          }
-
-          const addOptions = options.split(",").map((value) => ({
+          const addOptions = optionValue("options").map((value) => ({
             productId: data.addProducts[0],
-            name: value,
+            name: value.name
           }));
+
           addProductOptionMutate(
             { option: addOptions },
             {
-              onSuccess: () => {
+              onSuccess: (data) => {
                 queryClient.invalidateQueries("getProducts");
                 navigate(
-                  `/admin/${userId}/store/${storeId}/product/manage-product`,
+                  `/admin/${userId}/store/${storeId}/product/manage-product`
                 );
-              },
-            },
+              }
+            }
           );
-        },
-      },
+        }
+      }
     );
   };
 
@@ -284,7 +409,7 @@ const AdminManageProductAddItem = () => {
   useEffect(() => {
     if (error) {
       setError(`product.0.imageUrl`, {
-        message: error,
+        message: error
       });
     }
   }, [error]);
@@ -321,7 +446,7 @@ const AdminManageProductAddItem = () => {
           {fields.map((item, index) => (
             <fieldset key={item.id}>
               {location && <Images src={location} />}
-              <div>
+              <div className="product-input-container">
                 <Label htmlFor="imageUploader">섬네일</Label>
                 <AddimageUrlLabel htmlFor="imageUploader">
                   <IoIosAddCircle />
@@ -342,8 +467,7 @@ const AdminManageProductAddItem = () => {
                   fieldName={`product.${index}`}
                 />
               </div>
-
-              <div>
+              <div className="product-input-container">
                 <Label htmlFor="name">상품 이름</Label>
                 <InputDefault
                   id="name"
@@ -353,11 +477,12 @@ const AdminManageProductAddItem = () => {
                   register={register}
                   fieldName={`product.${index}`}
                   registerOptions={{
-                    required: "상품 이름은 꼭 입력해야해요",
+                    required: "상품 이름은 꼭 입력해야해요"
                   }}
                 />
               </div>
-              <div>
+              {errors.product && <p>{errors.product[index]?.name?.message}</p>}
+              <div className="product-input-container">
                 <Label htmlFor="price">상품 가격</Label>
                 <InputDefault
                   id="price"
@@ -367,22 +492,49 @@ const AdminManageProductAddItem = () => {
                   register={register}
                   fieldName={`product.${index}`}
                   registerOptions={{
-                    required: "상품의 가격은 꼭 입력해야해요",
+                    required: "상품의 가격은 꼭 입력해야해요"
                   }}
                 />
               </div>
-              <div>
-                <Label htmlFor="option">상품 옵션</Label>
-                <InputDefault
-                  id="option"
-                  type="text"
-                  placeholder="옵션은 반드시 ,로 구분해주세요."
-                  name="option"
-                  value={options}
-                  onChange={(e) => setOptions(e.target.value)}
-                />
-              </div>
-              <div>
+              {errors.product && <p>{errors.product[index]?.name?.message}</p>}
+              <OptionsField>
+                <div className="add-option-button-container">
+                  <Label>상품 옵션</Label>
+                  <button
+                    type="button"
+                    className="add-button"
+                    onClick={() => optionsAppend({ name: "" })}
+                  >
+                    <IoIosAddCircle />
+                    <span>옵션 추가</span>
+                  </button>
+                </div>
+                {optionsFields.map((optionField, index) => (
+                  <div className="option-input-container">
+                    <div className="option-label-button-container">
+                      <Label htmlFor="option">상품 옵션 {index + 1}</Label>
+                      <button
+                        type="button"
+                        onClick={() => optionsRemove(index)}
+                      >
+                        <IoIosRemoveCircle />
+                        <span>삭제</span>
+                      </button>
+                    </div>
+                    <InputDefault
+                      id="option"
+                      type="text"
+                      name="name"
+                      register={optionRegister}
+                      fieldName={`options.${index}`}
+                      placeholder="옵션의 이름을 입력해주세요"
+                      defaultValue={optionField.name}
+                    />
+                  </div>
+                ))}
+                {optionErrors.options && <p>{optionErrors.options.message}</p>}
+              </OptionsField>
+              <div className="product-input-container">
                 <Label htmlFor="infomation">상품 정보</Label>
                 <Textarea
                   id="infomation"

--- a/src/Page/Admin/Product/AdminManageProductAddItem.tsx
+++ b/src/Page/Admin/Product/AdminManageProductAddItem.tsx
@@ -268,7 +268,7 @@ interface ProductMutationValue extends ProductDefaultValue {
 
 const AdminManageProductAddItem = () => {
   const { storeId, userId } = useParams();
-  const { accessToken, refreshToken } = useRecoilValue(userState);
+  const { accessToken } = useRecoilValue(userState);
   const { error, location, uploadFile } = useImageUpload();
 
   const queryClient = useQueryClient();
@@ -284,7 +284,6 @@ const AdminManageProductAddItem = () => {
     }
   ]);
 
-  const [options, setOptions] = useState("");
   const { mutate: addProductMutate } = useAddProductsMutation<
     ProductDefaultValue[]
   >(graphqlReqeustClient(accessToken));
@@ -315,7 +314,6 @@ const AdminManageProductAddItem = () => {
 
   const {
     register: optionRegister,
-    handleSubmit: optionHandleSubmit,
     control: optionControl,
     formState: { errors: optionErrors },
     setError: optionSetError,
@@ -537,9 +535,9 @@ const AdminManageProductAddItem = () => {
               <div className="product-input-container">
                 <Label htmlFor="infomation">상품 정보</Label>
                 <Textarea
-                  id="infomation"
+                  id="description"
                   placeholder="상세 정보를 입력해주세요."
-                  name="infomation"
+                  name="description"
                   register={register}
                   fieldName={`product.${index}`}
                 />

--- a/src/Page/Admin/Product/AdminManageProductItemList.tsx
+++ b/src/Page/Admin/Product/AdminManageProductItemList.tsx
@@ -10,7 +10,7 @@ import {
   SelectOption,
   Option,
   selectOptionState,
-  selectProductListState,
+  selectProductListState
 } from "../../../state/productItemState";
 import { useNavigate, useParams } from "react-router-dom";
 import PageHeaderMessage from "../../../Components/PageHeader";
@@ -86,7 +86,7 @@ const AdminManageProductItemList = () => {
   const { isLoading } = useGetProductsQuery(
     graphqlReqeustClient(accessToken),
     {
-      id: Number(storeId),
+      id: Number(storeId)
     },
     {
       onSuccess: (data) => {
@@ -101,14 +101,15 @@ const AdminManageProductItemList = () => {
               description: value.description,
               options: value.options.map((item) => ({
                 id: Number(item.id),
-                name: item.name,
-              })),
-            }),
+                name: item.name
+              }))
+            })
           );
+
           setProductList(productList);
         }
-      },
-    },
+      }
+    }
   );
 
   const handleDeleteItem = () => {
@@ -138,7 +139,7 @@ const AdminManageProductItemList = () => {
               <ButtonItemWrapper
                 onClick={() =>
                   navigate(
-                    `/admin/${userId}/store/${storeId}/product/add-product`,
+                    `/admin/${userId}/store/${storeId}/product/add-product`
                   )
                 }
               >

--- a/src/Page/Admin/Product/AdminProductDetail.tsx
+++ b/src/Page/Admin/Product/AdminProductDetail.tsx
@@ -21,6 +21,10 @@ const Wrapper = styled.div`
   width: 100%;
   height: calc(100vh - 7rem);
   grid-template-columns: 1fr 1fr;
+  ${({ theme }) => theme.device.tablet} {
+    display: block;
+    grid-template-columns: unset;
+  }
 `;
 
 const ContainerDefaultStyle = styled.div`
@@ -62,6 +66,13 @@ const ContainerDefaultStyle = styled.div`
 const BasicInfoContainer = styled.div`
   display: grid;
   grid-template-rows: 1fr 1fr;
+  ${({ theme }) => theme.device.tablet} {
+    grid-template-rows: unset;
+    grid-auto-rows: minmax(30rem, auto);
+  }
+  ${({ theme }) => theme.device.mobile} {
+    grid-auto-rows: unset;
+  }
 `;
 
 const ImageContainer = styled.div`
@@ -72,7 +83,31 @@ const ImageContainer = styled.div`
     border-radius: 2rem;
   }
 `;
-const InfoContainer = styled(ContainerDefaultStyle)``;
+
+const InfoContainer = styled(ContainerDefaultStyle)`
+  .info-box {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    ul {
+      display: flex;
+      li {
+        font-weight: 700;
+        font-size: 2.4rem;
+        &:not(:first-child) {
+          margin-left: 1.4rem;
+        }
+      }
+    }
+    span {
+      font-size: 2rem;
+      strong {
+        font-size: 2.4rem;
+        font-weight: 700;
+      }
+    }
+  }
+`;
 const SalesInfoContainer = styled(BasicInfoContainer)``;
 const SalesInfoSummuryContainer = styled(ContainerDefaultStyle)`
   div:first-child {
@@ -89,7 +124,7 @@ const AdminProductDetail = () => {
     price: 0,
     options: [],
     imageUrl: "",
-    description: "",
+    description: ""
   });
   const { storeId, productId } = useParams();
   const productQuery = useGetProductsQuery(
@@ -107,16 +142,16 @@ const AdminProductDetail = () => {
                 price: item.price,
                 options: item.options.map((value) => ({
                   id: Number(value.id),
-                  name: value.name,
+                  name: value.name
                 })),
                 imageUrl: item.imageUrl,
-                description: item.description,
+                description: item.description
               };
             });
           setProduct(product);
         }
-      },
-    },
+      }
+    }
   );
 
   return (
@@ -132,20 +167,21 @@ const AdminProductDetail = () => {
         <InfoContainer>
           <h2>상품 기본정보</h2>
           <div className="info-box">
-            <h3>이름</h3>
-            <span>{product.name}</span>
+            <span>이름</span>
+            <span>
+              <strong>{product.name}</strong>
+            </span>
           </div>
           <div className="info-box">
-            <h3>등록 날짜</h3>
-            {/*TODO: 상품이 등록된 날짜가 제공되어야합니다.*/}
-            <span>2022년 1월 27일</span>
+            <span>가격</span>
+            <span>
+              <strong>
+                {translateLocalCurrency(product.price, "ko-KR")}원
+              </strong>
+            </span>
           </div>
           <div className="info-box">
-            <h3>가격</h3>
-            <span>{translateLocalCurrency(product.price, "ko-KR")}</span>
-          </div>
-          <div className="info-box">
-            <h3>옵션</h3>
+            <span>옵션</span>
             <ul>
               {product.options?.length !== 0
                 ? product.options?.map((value) => (
@@ -157,11 +193,13 @@ const AdminProductDetail = () => {
             </ul>
           </div>
           <div className="info-box">
-            <h3>정보</h3>
+            <span>정보</span>
             <span>
-              {product?.description
-                ? product.description
-                : "상품의 정보가 없습니다."}
+              <strong>
+                {product?.description
+                  ? product.description
+                  : "상품의 정보가 없습니다."}
+              </strong>
             </span>
           </div>
         </InfoContainer>

--- a/src/Page/Admin/Product/ProductItem.tsx
+++ b/src/Page/Admin/Product/ProductItem.tsx
@@ -3,7 +3,7 @@ import React, { MouseEvent, ReactNode, useEffect, useState } from "react";
 import { MdCreate } from "react-icons/md";
 import { useQueryClient } from "react-query";
 import { useNavigate, useParams } from "react-router-dom";
-import { useRecoilState, useRecoilValue } from "recoil";
+import { useRecoilState, useRecoilValue, useSetRecoilState } from "recoil";
 import styled from "styled-components";
 import ButtonDefaultStyle from "../../../Components/Buttons/ButtonDefault";
 import ToggleButton from "../../../Components/Buttons/ToggleButton";
@@ -17,7 +17,7 @@ import {
   Option,
   selectOptionState,
   selectProductListState,
-  updateProductState,
+  updateProductState
 } from "../../../state/productItemState";
 import { userState } from "../../../state/userState";
 import useModalHook from "../../../utils/customHooks/useModalHook";
@@ -145,9 +145,9 @@ const boxVariants: Variants = {
   hover: {
     scale: 1,
     transition: {
-      duration: 0.4,
-    },
-  },
+      duration: 0.4
+    }
+  }
 };
 
 const imageBoxVariants: Variants = {
@@ -155,9 +155,9 @@ const imageBoxVariants: Variants = {
   hover: {
     scale: 2,
     transition: {
-      duration: 0.4,
-    },
-  },
+      duration: 0.4
+    }
+  }
 };
 const ProductItem = ({ productData }: IProductItemProps) => {
   const navigate = useNavigate();
@@ -165,10 +165,10 @@ const ProductItem = ({ productData }: IProductItemProps) => {
   const queryClient = useQueryClient();
   const { accessToken } = useRecoilValue(userState);
   const [selectProduct, setSelectProduct] = useRecoilState(
-    selectProductListState,
+    selectProductListState
   );
-  const [selectUpdateProduct, setSelectUpdateProduct] =
-    useRecoilState(updateProductState);
+  const setSelectUpdateProduct = useSetRecoilState(updateProductState);
+
   const { isModal, setIsModal } = useModalHook();
   const selectOption = useRecoilValue(selectOptionState);
 
@@ -177,13 +177,13 @@ const ProductItem = ({ productData }: IProductItemProps) => {
     {
       onSuccess: () => {
         queryClient.invalidateQueries("getProducts");
-      },
-    },
+      }
+    }
   );
 
   const handleSelectItem = (
     e: React.MouseEvent<HTMLDivElement>,
-    productId: number,
+    productId: number
   ) => {
     if (selectOption?.options === "none") {
       navigate(`/admin/${userId}/store/${storeId}/product/${productId}`);
@@ -191,18 +191,18 @@ const ProductItem = ({ productData }: IProductItemProps) => {
     }
 
     const hasProduct = selectProduct.find(
-      (product) => product.id === productId,
+      (product) => product.id === productId
     );
 
     if (hasProduct) {
       setSelectProduct((products) =>
-        products.filter((product) => product.id !== productId),
+        products.filter((product) => product.id !== productId)
       );
       return;
     }
 
     const [selectedProduct] = productData.filter(
-      (product) => product.id === productId,
+      (product) => product.id === productId
     );
     setSelectProduct((products) => [...products, selectedProduct]);
   };

--- a/src/Page/MangeOrder/OrderStateList.tsx
+++ b/src/Page/MangeOrder/OrderStateList.tsx
@@ -175,9 +175,11 @@ const OrderStateList = () => {
   const orders = useRecoilValue(getOrderForFrontend);
   const { id, setId, isModal, setIsModal, confirm, setConfirm } =
     useModalHook();
+
   const { mutate: updateOrderStatusMutate } = useUpdateOrderStatusMutation(
     graphqlReqeustClient(accessToken)
   );
+
   const [orderStatus, setOrderStatus] = useState<OrderStatusType | null>(null);
 
   const handleSetModalItem = (
@@ -209,7 +211,7 @@ const OrderStateList = () => {
             console.log("success");
             setOrderStatus(null);
             setConfirm(false);
-            queryClient.invalidateQueries("getOrders");
+            queryClient.invalidateQueries("todayOrders");
           }
         }
       );
@@ -298,7 +300,7 @@ const OrderStateList = () => {
                         <strong>주문 수량</strong>
                         {product?.amount}
                       </span>
-                      <span data-optionid={product?.optionId}>
+                      <span data-optionid={product?.productOptionId}>
                         <strong>옵션</strong>
                         {product?.optionName}
                       </span>

--- a/src/Routers/Routers.tsx
+++ b/src/Routers/Routers.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import { Routes, Route, Navigate } from "react-router-dom";
 import Login from "../Page/Admin/Login/AdminLogin";
 import AdminManageProductAddItem from "../Page/Admin/Product/AdminManageProductAddItem";
@@ -6,7 +6,7 @@ import AdminManageProductItemList from "../Page/Admin/Product/AdminManageProduct
 import AdminMain from "../Page/Admin/Product/AdminManageProductMain";
 import AdminLayout from "../Layouts/AdminLayout";
 import PageNotFound from "../Page/Errors/404";
-// import MangeOrderMain from "../Page/MangeOrder/MangeOrderMain";
+import MangeOrderMain from "../Page/MangeOrder/MangeOrderMain";
 import ClientLayout from "../Layouts/ClientLayout";
 import ClientMain from "../Page/Client/ClientMain";
 import ClientMenu from "../Page/Client/ClientMenu";
@@ -28,6 +28,7 @@ import { storeState } from "../state/storeState";
 
 const Router = () => {
   const { isLogin } = useRecoilValue(userState);
+
   const store = useRecoilValue(storeState);
 
   return (
@@ -56,7 +57,7 @@ const Router = () => {
               path="manage-product"
               element={<AdminManageProductItemList />}
             />
-            {/* <Route path="manage-order" element={<MangeOrderMain />} /> */}
+            <Route path="manage-order" element={<MangeOrderMain />} />
             <Route path="add-product" element={<AdminManageProductAddItem />} />
           </Route>
           {store.isAvailable && (

--- a/src/generated/graphql.ts
+++ b/src/generated/graphql.ts
@@ -358,6 +358,14 @@ export type GetOrdersQueryVariables = Exact<{ [key: string]: never; }>;
 
 export type GetOrdersQuery = { __typename?: 'Query', myStores: Array<{ __typename?: 'Store', id: string, products: Array<{ __typename?: 'Product', id: string, name: string, price: number, options: Array<{ __typename?: 'Option', id: string, name: string }> }>, orders: Array<{ __typename?: 'Order', id: string, number: number, price: number, storeId: number, status: OrderStatusType, orderProducts: Array<{ __typename?: 'OrderProduct', orderId: number, productId: number, amount: number, productOptionId: number }> }> }> };
 
+export type TodayOrdersQueryVariables = Exact<{
+  offset?: InputMaybe<Scalars['Int']>;
+  limit?: InputMaybe<Scalars['Int']>;
+}>;
+
+
+export type TodayOrdersQuery = { __typename?: 'Query', todayOrders: Array<{ __typename?: 'Order', id: string, number: number, price: number, storeId: number, imp_uid: string, merchant_uid: string, status: OrderStatusType, orderProducts: Array<{ __typename?: 'OrderProduct', id: string, orderId: number, productId: number, amount: number, productOptionId: number }> }> };
+
 export type AddOrderMutationVariables = Exact<{
   order: AddOrderInput;
 }>;
@@ -414,6 +422,20 @@ export type AddProductOptionsMutationVariables = Exact<{
 
 
 export type AddProductOptionsMutation = { __typename?: 'Mutation', addProductOptions: boolean };
+
+export type RemoveProductOptionsMutationVariables = Exact<{
+  optionIds: RemoveProductOptionInput;
+}>;
+
+
+export type RemoveProductOptionsMutation = { __typename?: 'Mutation', removeProductOptions: boolean };
+
+export type UpdateProductOptionMutationVariables = Exact<{
+  option: EditProductOptionInput;
+}>;
+
+
+export type UpdateProductOptionMutation = { __typename?: 'Mutation', updateProductOption: boolean };
 
 export type StoreQueryVariables = Exact<{
   id: Scalars['Float'];
@@ -535,6 +557,40 @@ export const useGetOrdersQuery = <
     useQuery<GetOrdersQuery, TError, TData>(
       variables === undefined ? ['getOrders'] : ['getOrders', variables],
       fetcher<GetOrdersQuery, GetOrdersQueryVariables>(client, GetOrdersDocument, variables, headers),
+      options
+    );
+export const TodayOrdersDocument = `
+    query todayOrders($offset: Int, $limit: Int) {
+  todayOrders(offset: $offset, limit: $limit) {
+    id
+    number
+    price
+    storeId
+    imp_uid
+    merchant_uid
+    status
+    orderProducts {
+      id
+      orderId
+      productId
+      amount
+      productOptionId
+    }
+  }
+}
+    `;
+export const useTodayOrdersQuery = <
+      TData = TodayOrdersQuery,
+      TError = unknown
+    >(
+      client: GraphQLClient,
+      variables?: TodayOrdersQueryVariables,
+      options?: UseQueryOptions<TodayOrdersQuery, TError, TData>,
+      headers?: RequestInit['headers']
+    ) =>
+    useQuery<TodayOrdersQuery, TError, TData>(
+      variables === undefined ? ['todayOrders'] : ['todayOrders', variables],
+      fetcher<TodayOrdersQuery, TodayOrdersQueryVariables>(client, TodayOrdersDocument, variables, headers),
       options
     );
 export const AddOrderDocument = `
@@ -695,6 +751,42 @@ export const useAddProductOptionsMutation = <
     useMutation<AddProductOptionsMutation, TError, AddProductOptionsMutationVariables, TContext>(
       ['addProductOptions'],
       (variables?: AddProductOptionsMutationVariables) => fetcher<AddProductOptionsMutation, AddProductOptionsMutationVariables>(client, AddProductOptionsDocument, variables, headers)(),
+      options
+    );
+export const RemoveProductOptionsDocument = `
+    mutation removeProductOptions($optionIds: removeProductOptionInput!) {
+  removeProductOptions(optionIds: $optionIds)
+}
+    `;
+export const useRemoveProductOptionsMutation = <
+      TError = unknown,
+      TContext = unknown
+    >(
+      client: GraphQLClient,
+      options?: UseMutationOptions<RemoveProductOptionsMutation, TError, RemoveProductOptionsMutationVariables, TContext>,
+      headers?: RequestInit['headers']
+    ) =>
+    useMutation<RemoveProductOptionsMutation, TError, RemoveProductOptionsMutationVariables, TContext>(
+      ['removeProductOptions'],
+      (variables?: RemoveProductOptionsMutationVariables) => fetcher<RemoveProductOptionsMutation, RemoveProductOptionsMutationVariables>(client, RemoveProductOptionsDocument, variables, headers)(),
+      options
+    );
+export const UpdateProductOptionDocument = `
+    mutation updateProductOption($option: EditProductOptionInput!) {
+  updateProductOption(option: $option)
+}
+    `;
+export const useUpdateProductOptionMutation = <
+      TError = unknown,
+      TContext = unknown
+    >(
+      client: GraphQLClient,
+      options?: UseMutationOptions<UpdateProductOptionMutation, TError, UpdateProductOptionMutationVariables, TContext>,
+      headers?: RequestInit['headers']
+    ) =>
+    useMutation<UpdateProductOptionMutation, TError, UpdateProductOptionMutationVariables, TContext>(
+      ['updateProductOption'],
+      (variables?: UpdateProductOptionMutationVariables) => fetcher<UpdateProductOptionMutation, UpdateProductOptionMutationVariables>(client, UpdateProductOptionDocument, variables, headers)(),
       options
     );
 export const StoreDocument = `

--- a/src/graphql/order.graphql
+++ b/src/graphql/order.graphql
@@ -26,6 +26,25 @@ query getOrders {
   }
 }
 
+query todayOrders($offset: Int, $limit: Int) {
+  todayOrders(offset: $offset, limit: $limit) {
+    id
+    number
+    price
+    storeId
+    imp_uid
+    merchant_uid
+    status
+    orderProducts {
+      id
+      orderId
+      productId
+      amount
+      productOptionId
+    }
+  }
+}
+
 mutation addOrder($order: AddOrderInput!) {
   addOrder(order: $order)
 }

--- a/src/graphql/product.graphql
+++ b/src/graphql/product.graphql
@@ -36,3 +36,11 @@ mutation toggleProductIsAvailable($id: Float!) {
 mutation addProductOptions($option: [AddProductOptionInput!]!) {
   addProductOptions(option: $option)
 }
+
+mutation removeProductOptions($optionIds: removeProductOptionInput!) {
+  removeProductOptions(optionIds: $optionIds)
+}
+
+mutation updateProductOption($option: EditProductOptionInput!) {
+  updateProductOption(option: $option)
+}

--- a/src/state/orderState.ts
+++ b/src/state/orderState.ts
@@ -5,7 +5,7 @@ export enum OrderStatusType {
   Canceled = "CANCELED",
   Complete = "COMPLETE",
   Done = "DONE",
-  Ready = "READY",
+  Ready = "READY"
 }
 
 export interface OrderProducts {
@@ -25,12 +25,13 @@ export interface Order {
 }
 
 export interface ProductInfo {
+  id: string;
   productId: number;
   orderId: number;
   amount: number;
   productName: string;
   productPrice: number;
-  optionId: string;
+  productOptionId: string;
   optionName: string;
 }
 
@@ -45,12 +46,12 @@ export interface NewOrder {
 
 export const orderStatusState = atom<OrderStatusType>({
   key: "orderStatusState",
-  default: OrderStatusType.Ready,
+  default: OrderStatusType.Ready
 });
 
 export const orderStateForFrontend = atom<NewOrder[]>({
   key: "orderStateForFrontend",
-  default: [],
+  default: []
 });
 
 export const getOrderForFrontend = selector<NewOrder[]>({
@@ -66,19 +67,19 @@ export const getOrderForFrontend = selector<NewOrder[]>({
         return orders.filter((item) => item.status === OrderStatusType.Done);
       case "COMPLETE":
         return orders.filter(
-          (item) => item.status === OrderStatusType.Complete,
+          (item) => item.status === OrderStatusType.Complete
         );
       case "CANCELED":
         return orders.filter(
-          (item) => item.status === OrderStatusType.Canceled,
+          (item) => item.status === OrderStatusType.Canceled
         );
       default:
         return orders;
     }
-  },
+  }
 });
 
 export const orderType = atom({
   key: "orderType",
-  default: "",
+  default: ""
 });

--- a/src/state/productItemState.ts
+++ b/src/state/productItemState.ts
@@ -33,7 +33,7 @@ export interface SalesInfo {
 export enum Option {
   NONE = "none",
   DELETE = "delete",
-  UPDATE = "update",
+  UPDATE = "update"
 }
 
 export interface SelectOption {
@@ -42,31 +42,31 @@ export interface SelectOption {
 
 export const productListState = atom({
   key: "productList",
-  default: <ProductListValues[]>[],
+  default: <ProductListValues[]>[]
 });
 
 export const selectProductListState = atom({
   key: "selectProductList",
-  default: <ProductListValues[]>[],
+  default: <ProductListValues[]>[]
 });
 
 export const selectOptionState = atom<SelectOption>({
   key: "selectOption",
-  default: { options: Option.NONE },
+  default: { options: Option.NONE }
 });
 
 // client
 export const selectMenuListState = atom({
   key: "selectMenuListState",
-  default: <IOrderSelectedItem[]>[],
+  default: <IOrderSelectedItem[]>[]
 });
 
 export const isCurrentSelectItemState = atom({
   key: "isCurrentSelectItemState",
-  default: 0,
+  default: 0
 });
 
 export const updateProductState = atom({
   key: "updateProductState",
-  default: <ProductListValues>{},
+  default: <ProductListValues>{}
 });


### PR DESCRIPTION
# 개요
주문 데이터 쿼리 변경, 상품 옵션 수정,삭제,추가, 상품 세부 페이지 구현

# 작업 내용
사용자 주문을 오늘 데이터만 가져옵니다. 
상품 옵션을 추가 삭제할 수 있습니다. (수정은 동작하지 않습니다.)
상품 세부 페이지에 반응형 코드를 추가하였습니다.
