### PR TITLE
fix: 주소창 userId 표시 변경

### DIFF
--- a/src/Page/Errors/404.tsx
+++ b/src/Page/Errors/404.tsx
@@ -1,7 +1,32 @@
-import React from "react";
+import { useNavigate } from "react-router-dom";
+import styled from "styled-components";
+import ButtonDefaultStyle from "../../Components/Buttons/ButtonDefault";
+import { SubTitle2 } from "../../mixin";
+const Wrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  margin-top: 1rem;
+  p {
+    ${SubTitle2}
+  }
+`;
+const ConfirmButton = styled(ButtonDefaultStyle)`
+  color: ${(props) => props.theme.color.fontColorWhite};
+  font-size: 2rem;
+  margin: 1rem 0;
+`;
 
 const PageNotFound = () => {
-  return <div>페이지를 찾을 수 없습니다.</div>;
+  const navigate = useNavigate();
+  return (
+    <Wrapper>
+      <p>페이지를 찾을 수 없습니다.</p>
+      <ConfirmButton onClick={() => navigate("/")}>
+        메인으로 이동하기
+      </ConfirmButton>
+    </Wrapper>
+  );
 };
 
 export default PageNotFound;

--- a/src/Routers/Routers.tsx
+++ b/src/Routers/Routers.tsx
@@ -27,10 +27,8 @@ import AdminProductDetail from "../Page/Admin/Product/AdminProductDetail";
 import { storeState } from "../state/storeState";
 
 const Router = () => {
-  const { isLogin } = useRecoilValue(userState);
-
+  const { isLogin, id: userId } = useRecoilValue(userState);
   const store = useRecoilValue(storeState);
-
   return (
     <Routes>
       {isLogin && (
@@ -82,8 +80,8 @@ const Router = () => {
           </>
         ) : (
           <Route
-            path="/"
-            element={<Navigate to="/admin/:userId/store/list" />}
+            path=""
+            element={<Navigate to={`/admin/${userId}/store/list`} />}
           />
         )}
         <Route path="signup" element={<SignUp />} />


### PR DESCRIPTION
client 화면에서 admin으로 이동하는 경우 주소에 :userId 가 표시되지 않도록 Landing 라우터를 변경했습니다.
NotFound 페이지에서 메인으로 돌아가는 버튼을 추가했습니다.